### PR TITLE
Fix for the FAQ section padding

### DIFF
--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -400,7 +400,10 @@
 
   @media only screen and (max-width: 1500px) {
     .faq-intro {
-      padding: 6rem 12rem;
+      padding: 6rem 10rem;
+    }
+    h1 {
+      font-size: 3.4rem;
     }
     .summer-container {
       display: none;


### PR DESCRIPTION
Had following issue on my laptop's screen size: https://i.ibb.co/zNjvWbm/screencapture-welcometomygarden-org-2020-08-05-21-16-14-1.png

Check the FAQ section: title doesn't fit on one line and the green section is bigger than dropdown list. 