### PR TITLE
fix(banner): z-index should be lower than nav

### DIFF
--- a/src/components/Nav/Top/TopNav.svelte
+++ b/src/components/Nav/Top/TopNav.svelte
@@ -54,7 +54,7 @@
     left: 0;
     width: 100%;
     padding: 0 0 0 5rem;
-    z-index: 100;
+    z-index: 110;
     background-color: var(--color-white);
     box-shadow: 0 0 3.3rem rgba(0, 0, 0, 0.1);
   }

--- a/src/components/Nav/Top/UserDropdown.svelte
+++ b/src/components/Nav/Top/UserDropdown.svelte
@@ -101,7 +101,7 @@
 
   .user-dropdown {
     position: absolute;
-    z-index: 110;
+    z-index: 120;
     top: calc(var(--height-nav) - 1.5rem);
     right: 0;
     width: 21rem;


### PR DESCRIPTION
before|after
---|---
<img width="299" alt="Screenshot 2022-03-28 at 15 05 55" src="https://user-images.githubusercontent.com/6270048/160404595-4c07b3d3-ed9e-4113-8ab0-b5ed54e2600a.png"> | <img width="427" alt="Screenshot 2022-03-28 at 15 05 34" src="https://user-images.githubusercontent.com/6270048/160404589-8baf7560-5bed-4e4c-80f9-6afb0a160969.png">
