### PR TITLE
fix(header): wording for slowby

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,7 @@
     "sign-in": "Sign in",
     "garden": "Garden",
     "shop": "Shop",
-    "slowby": "Secrets Trips"
+    "slowby": "Secret Trips"
   },
   "ui": {
     "card": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -19,7 +19,7 @@
     "password": "Mot de passe",
     "garden": "Jardin",
     "shop": "Shop",
-    "slowby": "Secrets Trips"
+    "slowby": "Secret Trips"
   },
   "ui": {
     "card": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -19,7 +19,7 @@
     "sign-in": "Inloggen",
     "garden": "Tuin",
     "shop": "Shop",
-    "slowby": "Secrets Trips"
+    "slowby": "Secret Trips"
   },
   "ui": {
     "card": {


### PR DESCRIPTION
For me "Secret Trips" reads better than "Secrets Trips", although it's still not super clear to me what it really means, but at least "secret trips" is used in the banner too.