### PR TITLE
Lower footer to 12em

### DIFF
--- a/src/pages/_layout.svelte
+++ b/src/pages/_layout.svelte
@@ -58,7 +58,7 @@
 <style>
   .app {
     --height-nav: 7rem;
-    --height-footer: 18rem;
+    --height-footer: 12rem;
     width: 100%;
     height: 100%;
     position: relative;


### PR DESCRIPTION
Hi

This is a first (and very minor) pull request. When browsing the map on my small screen, the footer is taking up a lot of space. This reduces it a bit.

Thanks for considering it!