### PR TITLE
Auth firestore rules & verification improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ package-lock.json
 # Tests
 /coverage
 /.nyc_output
+firestore-coverage.html
 
 # IDEs and editors
 /.idea
@@ -41,3 +42,5 @@ wtmg.config.json
 /build
 /.svelte-kit
 /package
+
+vite.config.ts.timestamp*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "chflick.firecode",
         "svelte.svelte-vscode",
         "esbenp.prettier-vscode",
-        "mikestead.dotenv"
+        "mikestead.dotenv",
+        "zixuanchen.vitest-explorer"
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,52 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Local Development",
+      "dependsOn": [
+        "copy-demo-env",
+        "npm: firebase:demo",
+        "npm: dev"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "group": "local-dev"
+      }
+    },
+    {
+      "type": "npm",
+      "script": "firebase:demo",
+      "problemMatcher": [],
+      "label": "npm: firebase:demo",
+      "detail": "firebase --project demo-test emulators:start",
+      "group": {
+        "kind": "build"
+      },
+      "presentation": {
+        "group": "local-dev"
+      }
+    },
+    {
+      "type": "npm",
+      "script": "dev",
+      "problemMatcher": [],
+      "label": "npm: dev",
+      "detail": "vite dev",
+      "group": {
+        "kind": "build",
+      },
+      "presentation": {
+        "group": "local-dev"
+      }
+    },
+    {
+      "type": "shell",
+      "label": "copy-demo-env",
+      "detail": "Copy Demo-test env",
+      "command": "if [[ -a .env.demo-test ]] then cp .env.demo-test .env; fi"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,12 @@
       "type": "shell",
       "label": "copy-demo-env",
       "detail": "Copy Demo-test env",
-      "command": "if [[ -a .env.demo-test ]] then cp .env.demo-test .env; fi"
+      "command": "if [[ -a .env.demo-test ]] then cp .env.demo-test .env; fi",
+      "presentation": {
+        "revealProblems": "onProblem",
+        "panel": "new",
+        "close": true
+      }
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,7 @@ Use [Discussions](https://github.com/WelcometoMyGarden/welcometomygarden/discuss
 Problems & bug reports are welcome in [Issues](https://github.com/WelcometoMyGarden/welcometomygarden/issues).
 
 If you want to contribute to the code, check the [README](https://github.com/WelcometoMyGarden/welcometomygarden) for instructions.
+
+## Conventions
+
+For commit messages, we try to use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) again since Jan 25th, 2023, with [extension types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) defined by Angular. Older commits by @micleyman were also following this convention.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ yarn dev
 
 This will run a SvelteKit app dev server via Vite (our frontend). SvelteKit also has server-side (backend) capabilities, but for the moment we use it as a pure frontend static site generator via [adapter-static](https://kit.svelte.dev/docs/adapters#supported-environments-static-sites).
 
+If you use VSCode (recommended), you can also execute both commands at the same time using the pre-configured [Run Build Task](https://code.visualstudio.com/Docs/editor/tasks#_typescript-hello-world) command.
+
 ### What can you do now?
 
 Assuming that you did the above, you now have a partially functioning development environment!

--- a/api/src/mail.js
+++ b/api/src/mail.js
@@ -38,6 +38,13 @@ exports.sendAccountVerificationEmail = (email, name, verificationLink) => {
   if (API_KEY == null) {
     console.warn(NO_API_KEY_WARNING);
     console.info(JSON.stringify(msg));
+    // To help debugging the /auth/action verification page, transform the local auth URL
+    if (verificationLink.includes('/emulator/action')) {
+      console.info(
+        'Transformed /auth/action URL: ',
+        `"${verificationLink.replace(/http:\/\/[^/]+\/emulator/, `${FRONTEND_URL}/auth`)}"`
+      );
+    }
     return Promise.resolve();
   }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,10 @@
+
+// This file is auto-formatted by the VS Code ChFlick.firecode extension
+// Name: Firestore Rules
+// Id: ChFlick.firecode
+// Description: Firestore Security Rules Syntax Highlighting and Suggestions
+// VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=ChFlick.firecode
+
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
@@ -40,16 +47,6 @@ service cloud.firestore {
       return field in request.resource.data;
     }
 
-
-    function validateUserRequest(user) {
-      return isNonEmptyString(user.firstName);
-    }
-
-    function validateUserPrivateRequest(user) {
-      // return isNonEmptyString(user.lastName);
-      return true;
-    }
-
     // General validation functions
 
     function isNonEmptyString(str) {
@@ -57,13 +54,16 @@ service cloud.firestore {
       str.size() > 0
     }
 
-
-
     // Public user collection
 
+    function validateUserRequest(user) {
+      return isNonEmptyString(user.firstName);
+    }
 
     match /users/{userId} {
+      // user documents are always created by firebase-admin.
       allow create: if false;
+      // Public document data can always be read.
       allow read;
       allow update:
       if isSignedIn() &&
@@ -73,7 +73,13 @@ service cloud.firestore {
 
     // Private user collection
 
+    function validateUserPrivateRequest(user) {
+      // return isNonEmptyString(user.lastName);
+      return true;
+    }
+
     match /users-private/{userId} {
+      // User-private documents are always created by firebase-admin.
       allow create: if false;
       allow read: if isOwner(userId);
       allow update:
@@ -87,22 +93,26 @@ service cloud.firestore {
 
     // Garden functions
 
+    // TODO unused
     function validateDescription(description) {
       return description is string &&
       description.size() >= 20 &&
       description.size() <= 300
     }
 
+    // TODO unused
     function validateContactLanguages(languages) {
-      /* TODO: verify firestore enum security rule? */
+      // TODO: verify firestore enum security rule?
       // return languages in ['Dutch', 'French', 'German', 'English']
       return true;
     }
 
+    // TODO unused
     function validateLocation(location) {
       return location.keys().hasAll(['latitude', 'longitude']) && location.latitude is latlng && location.longitude is latlng
     }
 
+    // TODO unused
     function validateFacilities(facilities) {
       return facilities.keys().hasAll([
       'drinkableWater',
@@ -158,10 +168,7 @@ service cloud.firestore {
       isOwner(userId)
     }
 
-
-
     // Chats
-
 
     function getChatUsers(chatId) {
       return get(/databases/$(database)/documents/chats/$(chatId)).data.users;

--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,11 @@
 // Description: Firestore Security Rules Syntax Highlighting and Suggestions
 // VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=ChFlick.firecode
 
+// Helpful docs on data type validation with `is`
+// - https://stackoverflow.com/a/58034743/4973029
+// - https://youtu.be/qbd_4LT0Y4s?t=652
+// Can't find this in the official docs so far!
+
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
@@ -56,39 +61,42 @@ service cloud.firestore {
 
     // Public user collection
 
-    function validateUserRequest(user) {
-      return isNonEmptyString(user.firstName);
+    function validateUserState(user) {
+      // See src/lib/models/Users.ts -> UserPublic
+      // and api/src/auth.js -> createUser
+      return isNonEmptyString(user.firstName) &&
+      isNonEmptyString(user.countryCode)
     }
 
     match /users/{userId} {
-      // user documents are always created by firebase-admin.
-      allow create: if false;
-      // Public document data can always be read.
       allow read;
       allow update:
       if isSignedIn() &&
-      validateUserRequest(request.resource.data) &&
-      isOwner(userId)
+      isOwner(userId) &&
+      validateUserState(request.resource.data) &&
+      // Don't allow superfan status to be changed by clients
+      !request.resource.data.diff(resource.data).affectedKeys().hasAny(['superfan'])
     }
 
     // Private user collection
 
-    function validateUserPrivateRequest(user) {
-      // return isNonEmptyString(user.lastName);
-      return true;
+    function validateUserPrivateState(user) {
+      return isNonEmptyString(user.lastName)
+        && user.consentedAt is timestamp
+        && user.emailPreferences is map
+        && user.emailPreferences.newChat is bool
+        && user.emailPreferences.news is bool
+      // Don't allow stripe properties to be changed by clients
+        && !request.resource.data.diff(resource.data).affectedKeys().hasAny(['stripeCustomerId', 'stripeSubscription'])
     }
 
     match /users-private/{userId} {
-      // User-private documents are always created by firebase-admin.
-      allow create: if false;
+      // users-private documents are always created by firebase-admin.
       allow read: if isOwner(userId);
       allow update:
       if isSignedIn() &&
-      validateUserPrivateRequest(request.resource.data) &&
-      isOwner(userId)
-      allow delete:
-      if isSignedIn() &&
-      isOwner(userId)
+      isOwner(userId) &&
+      validateUserPrivateState(request.resource.data)
     }
 
     // Garden functions

--- a/firestore.rules
+++ b/firestore.rules
@@ -14,7 +14,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    //  Generic functions
+    // Generic functions
 
     function isOwner(userId) {
       return request.auth.uid == userId

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "welcome-to-my-garden",
   "license": "GPL-3.0-or-later",
   "description": "a platform allowing citizens to put their garden freely at disposal as a rudimentary campsite to travelers.",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "engines": {
     "node": "16"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:prod": "vite build --mode production",
     "build:staging": "vite build --mode staging",
     "preview": "vite preview",
-    "test": "playwright test",
+    "test:e2e": "playwright test",
+    "test:unit": "vitest",
     "check": "svelte-kit sync && svelte-check --compiler-warnings 'security-anchor-rel-noreferrer:ignore' --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --compiler-warnings 'security-anchor-rel-noreferrer:ignore' --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
@@ -24,6 +25,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^2.0.5",
     "@playwright/test": "^1.29.2",
     "@stripe/stripe-js": "^1.46.0",
     "@sveltejs/adapter-static": "^1.0.0-next.48",
@@ -57,7 +59,8 @@
     "svg-inline-loader": "^0.8.2",
     "tslib": "^2.3.1",
     "typescript": "^4.9.4",
-    "vite": "^4.0.4"
+    "vite": "^4.0.4",
+    "vitest": "^0.28.2"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "check": "svelte-kit sync && svelte-check --compiler-warnings 'security-anchor-rel-noreferrer:ignore' --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --compiler-warnings 'security-anchor-rel-noreferrer:ignore' --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --plugin-search-dir . --check . && eslint .",
-    "format": "prettier --plugin-search-dir . --write ."
+    "format": "prettier --plugin-search-dir . --write .",
+    "firebase:demo": "firebase --project demo-test emulators:start",
+    "firebase:staging": "firebase --project wtmg-dev emulators:start --only functions"
   },
   "publishConfig": {
     "access": "public"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
+  testDir: './tests/e2e',
   webServer: {
     command: 'npm run build && npm run preview',
     port: 4173

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -9,7 +9,8 @@ import {
   updatingMailPreferences,
   updatingSavedGardens
 } from '@/lib/stores/user';
-import type { Garden, UserPrivate } from '@/lib/types/Garden';
+import type { Garden } from '@/lib/types/Garden';
+import type { UserPrivate } from '../models/User';
 
 export const doesPublicUserExist = async (uid: string) => {
   const userDoc = await getDoc(doc(db(), USERS, uid));
@@ -44,7 +45,7 @@ const getCampsiteInformation = async (uid: string) => {
 };
 
 /**
- * Gets all non-id data related to the user from the user, user-private and campsite collections.
+ * Gets all non-id data related to the user from the user, users-private and campsite collections.
  */
 export const getAllUserInfo = async (userId: string) => {
   const publicUserProfile = await getPublicUserProfile(userId);

--- a/src/lib/components/Garden/Form.svelte
+++ b/src/lib/components/Garden/Form.svelte
@@ -19,6 +19,7 @@
     waterIcon,
     tentIcon
   } from '$lib/images/icons';
+  import ReloadSuggestion from '../ReloadSuggestion.svelte';
 
   const dispatch = createEventDispatcher();
 
@@ -172,6 +173,7 @@
                 )}</a>`
               }
             })}
+            <ReloadSuggestion />
           </p>
         {:else}
           <p>

--- a/src/lib/components/ReloadSuggestion.svelte
+++ b/src/lib/components/ReloadSuggestion.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { _ } from 'svelte-i18n';
+  import { auth } from '../api/firebase';
+
+  // Migitates https://github.com/WelcometoMyGarden/welcometomygarden/issues/297
+  // NOTE: Might perform an unnecessary double reload when being redirected by
+  // checkAndHandleUnverified
+  auth().currentUser?.reload();
+</script>
+
+<p class="reload-suggestion">
+  {@html $_('account.verify.reload-suggestion', {
+    values: {
+      reloading: `<a onclick="window.location.reload()">${$_('account.verify.reloading-text')}</a>`
+    }
+  })}
+</p>
+
+<style>
+  .reload-suggestion {
+    margin-top: 1rem;
+    font-style: italic;
+  }
+  .reload-suggestion :global(a),
+  .reload-suggestion :global(a:link),
+  .reload-suggestion :global(a:visited),
+  .reload-suggestion :global(a:active) {
+    cursor: pointer;
+    color: var(--color-orange);
+    text-decoration: underline;
+  }
+  .reload-suggestion :global(a:hover) {
+    text-decoration: none;
+  }
+</style>

--- a/src/lib/routes.js
+++ b/src/lib/routes.js
@@ -3,6 +3,7 @@ export default {
   ADD_GARDEN: '/garden/add',
   ABOUT_SUPERFAN: '/about-superfan',
   ABOUT_US: '/about-us',
+  AUTH_ACTION: '/auth/action',
   BECOME_SUPERFAN: '/become-superfan',
   CHAT: '/chat',
   COOKIE_POLICY: '/terms/cookies',

--- a/src/lib/types/Garden.ts
+++ b/src/lib/types/Garden.ts
@@ -14,15 +14,6 @@ export type Garden = {
   listed: boolean;
 };
 
-export type UserPrivate = {
-  emailPreferences?: {
-    newChat?: boolean;
-    news?: boolean;
-  };
-  lastName?: string;
-  stripeCustomerId?: string;
-};
-
 type latLng = {
   latitude: number;
   longitude: number;

--- a/src/lib/util/countries.js
+++ b/src/lib/util/countries.js
@@ -1,3 +1,7 @@
+/**
+ * What this map probably is:
+ * ISO 3166 Alpha-2 country codes mapped onto their English country names.
+ */
 export default {
   AF: 'Afghanistan',
   AL: 'Albania',

--- a/src/lib/util/createSlug.ts
+++ b/src/lib/util/createSlug.ts
@@ -1,0 +1,16 @@
+import removeDiacritics from './removeDiacritics';
+
+/**
+ * Creates a slug suitable for using in URLs from a generic string.
+ */
+export default (str: string) => {
+  const withoutDiacritics = removeDiacritics(str);
+  return (
+    withoutDiacritics
+      // Turn adjacent whitespace into dashes,
+      .replace(/\s+/g, '-')
+      // remove non-alphanumerical characters (retain dashes)
+      .replace(/[^A-Za-z0-9-]/g, '')
+      .toLocaleLowerCase()
+  );
+};

--- a/src/lib/util/removeDiacritics.ts
+++ b/src/lib/util/removeDiacritics.ts
@@ -221,7 +221,7 @@ const defaultDiacriticsRemovalMap = [
   }
 ];
 
-export default (str) => {
+export default (str: string) => {
   let stripped = str;
   for (let i = 0; i < defaultDiacriticsRemovalMap.length; i += 1) {
     stripped = stripped.replace(

--- a/src/lib/util/types/isFirebaseError.ts
+++ b/src/lib/util/types/isFirebaseError.ts
@@ -1,0 +1,5 @@
+import type { FirebaseError } from 'firebase/app';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default (object: any): object is FirebaseError =>
+  !!object && typeof object.code === 'string' && typeof object.name === 'string';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -622,7 +622,8 @@
       "title": "Add your garden"
     },
     "manage": {
-      "title": "Manage garden"
+      "title": "Manage garden",
+      "add-first": "Please add a garden first."
     },
     "form": {
       "title": "Add your garden to the map",
@@ -954,7 +955,9 @@
       "title": "Verify your email",
       "text": "You need to verify your email address if you want to chat or add a garden.",
       "button": "Resend email",
-      "sent": "Email sent!"
+      "sent": "Email sent!",
+      "reload-suggestion": "Did you already verify? Try {reloading} the page.",
+      "reloading-text": "reloading"
     },
     "preferences": {
       "title": "Email preferences",
@@ -993,12 +996,15 @@
     "password": {
       "expired": "This password reset link has expired. Please request a new one"
     },
+    "unsigned": "Please sign in first.",
     "verification": {
       "verifying": "Verifying your email address... Don't close this page, this could take a few seconds.",
+      "reloading": "Reloading your account...",
       "success": "Your email address was verified successfully!",
       "refresh": "Your email has already been verified.",
       "expired": "This verification link has expired. Please request a new one.",
-      "unsigned": "Please sign in first"
+      "sign-in": "Sign in to continue.",
+      "unverified": "Please verify your email first."
     },
     "logged-out": "You have been logged out elsewhere. Please log in again."
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1020,7 +1020,7 @@
       },
       "first-name": {
         "set": "Please enter a first name. This is how you're shown to other users",
-        "max": "Your first name can only be 25 characters long so we can display it properly. Feel free too abbreviate or choose a nickname"
+        "max": "Your first name can only be 25 characters long so we can display it properly. Feel free too abbreviate or choose a nickname."
       },
       "last-name": "Please enter your last name. This won't be shared with other users",
       "country": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -677,7 +677,8 @@
       "title": "Ajoutez votre jardin"
     },
     "manage": {
-      "title": "Gérer le jardin"
+      "title": "Gérer le jardin",
+      "add-first": "Veuillez d'abord ajouter votre jardin"
     }
   },
   "sign-in": {
@@ -976,7 +977,9 @@
       "title": "Confirmez votre adresse électronique",
       "sent": "Courriel envoyé !",
       "button": "Renvoyer le courriel",
-      "text": "Vous devez vérifier votre adresse électronique si vous voulez discuter ou ajouter un jardin."
+      "text": "Vous devez vérifier votre adresse électronique si vous voulez discuter ou ajouter un jardin.",
+      "reload-suggestion": "Avez vous déjà verifié? Essaye de {reloading} la page.",
+      "reloading-text": "recharger"
     },
     "preferences": {
       "text": "M'envoyer des courriels quand :",
@@ -987,12 +990,15 @@
     "title": "Compte"
   },
   "auth": {
+    "unsigned": "Veuillez vous inscrire d'abord.",
     "verification": {
       "verifying": "Vérification de votre email en cours... Merci de ne pas fermer cette page, cela peut prendre quelques secondes.",
+      "reloading": "Rechargement de votre compte en cours...",
       "refresh": "Votre adresse électronique a déjà été vérifié.",
       "success": "Votre adresse électronique a été vérifiée avec succès !",
       "expired": "Ce lien de vérification a expiré. Veuillez en demander un nouveau.",
-      "unsigned": "Veuillez vous inscrire d'abord"
+      "sign-in": "Veuillez vous inscrire pour continuer.",
+      "unverified": "Veuillez vérifier voter adresse électronique d'abord."
     },
     "password": {
       "expired": "Ce lien de réinitialisation du mot de passe a expiré. Veuillez en demander un nouveau"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -185,7 +185,8 @@
       "title": "Voeg jouw tuin toe"
     },
     "manage": {
-      "title": "Beheer jouw tuin"
+      "title": "Beheer jouw tuin",
+      "add-first": "Voeg eerst jouw tuin toe."
     },
     "form": {
       "title": "Voeg jouw tuin toe aan de kaart",
@@ -517,7 +518,9 @@
       "title": "Bevestig jouw e-mail",
       "text": "Je moet jouw e-mailadres controleren als je wilt chatten of een tuin wilt toevoegen.",
       "button": "E-mail opnieuw versturen",
-      "sent": "E-mail verzonden!"
+      "sent": "E-mail verzonden!",
+      "reload-suggestion": "Heb je al geverifieerd? Probeer de pagina te {reloading}.",
+      "reloading-text": "herladen"
     },
     "preferences": {
       "title": "E-mail voorkeuren",
@@ -556,12 +559,15 @@
     "password": {
       "expired": "De link om jouw wachtwoord te herstellen is verlopen, probeer nog eens."
     },
+    "unsigned": "Gelieve eerst in te loggen",
     "verification": {
       "verifying": "Je e-mailadres wordt geverifieerd... Gelieve deze pagina niet te sluiten, dit kan enkele seconden duren.",
+      "reloading": "Je account wordt herladen...",
       "success": "Jouw e-mailadres is met succes geverifieerd!",
       "refresh": "Jouw e-mail is al geverifieerd.",
       "expired": "Deze verificatielink is vervallen. Vraag een nieuwe aan.",
-      "unsigned": "Gelieve eerst in te loggen"
+      "sign-in": "Log in om verder te gaan.",
+      "unverified": "Gelieve eerst je email te verifiëren."
     }
   },
   "register": {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,10 +39,12 @@
 
   let vh = `0px`;
 
+  // Manage chat observers
   user.subscribe(async (tempUser) => {
     if (!unsubscribeFromChatObserver && tempUser && tempUser.emailVerified)
       unsubscribeFromChatObserver = await createChatObserver(tempUser.uid);
 
+    // Unsubscribe if the user logged out
     if (unsubscribeFromChatObserver && !tempUser) unsubscribeFromChatObserver();
 
     if (tempUser && !tempUser.communicationLanguage && $locale)

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -5,7 +5,7 @@
   import { updateMailPreferences } from '@/lib/api/user';
   import { resendAccountVerification } from '@/lib/api/auth';
   import { changeListedStatus } from '$lib/api/garden';
-  import { getUser, user } from '@/lib/stores/auth';
+  import { user } from '@/lib/stores/auth';
   import { updatingMailPreferences } from '$lib/stores/user';
   import { Avatar, Icon, Button, LabeledCheckbox } from '$lib/components/UI';
   import { flagIcon, emailIcon } from '$lib/images/icons';
@@ -13,6 +13,7 @@
   import routes from '$lib/routes';
   import { SUPPORT_EMAIL } from '$lib/constants';
   import { createCustomerPortalSession } from '@/lib/api/functions';
+  import ReloadSuggestion from '@/lib/components/ReloadSuggestion.svelte';
 
   if (!$user) {
     goto(routes.SIGN_IN);
@@ -121,6 +122,7 @@
             {:else}
               <p class="resend-verification">{$_('account.verify.sent')}</p>
             {/if}
+            <ReloadSuggestion />
           </div>
         </section>
       {/if}

--- a/src/routes/auth/action/+page.svelte
+++ b/src/routes/auth/action/+page.svelte
@@ -2,12 +2,15 @@
   // This page is set up according to the instructions here:
   // https://firebase.google.com/docs/auth/custom-email-handler#link_to_your_custom_handler_in_your_email_templates
   //
-  // It does not yet seem to be possible to set a custom handler URL for the local auth emulator: that one handles verifications internally with URLs of the form:
+  // It does NOT yet seem to be possible to set a custom handler URL for the local auth emulator: that one handles verifications internally with URLs of the form:
   // http://127.0.0.1:9099/emulator/action?mode=verifyEmail&lang=en&oobCode=EkpfDbT1x6s2Odi2hwAzJtW6dmoWX9BXjRWE96VWUrxXxgmbW7H-CW&apiKey=fake-api-key&continueUrl=http%3A%2F%2Flocalhost%3A5173%2Faccount
   // At the time of writing, someone submitted a PR for this though: https://github.com/firebase/firebase-tools/pull/5360
+  // It IS possible to test this page locally  by taking local auth email verification URLs of the form
+  // pasting the query string ?... bit of the above URL after http://localhost:5173/auth/action manually.
   //
   // In the demo, when the page /account continueUrl is loaded:
-  // The onIdTokenChanged in auth.ts will get notified that the email address was verified.
+  // The onIdTokenChanged in auth.ts will get notified that the email address was verified, but only when it is
+  // in a tab on the same window (https://github.com/WelcometoMyGarden/welcometomygarden/issues/297).
   // It will detect that email_verified is not yet true as a token claim, and will force-reset the token.
   // The force-reset triggers idTokenChanged everywhere.
   import { _ } from 'svelte-i18n';
@@ -35,7 +38,7 @@
   // It must be on the same host as this page.
   // So far, this is not used, but this adds support for when we want to use it.
   const continueUrl = $page.url.searchParams.get('continueUrl');
-  const continueUrlPathMatch = /https?:\/\/[^\/]+(\/.*$)/.exec(continueUrl ?? '');
+  const continueUrlPathMatch = /https?:\/\/[^/]+(\/.*$)/.exec(continueUrl ?? '');
   let gotoPath: string | null = null;
   if (continueUrlPathMatch) {
     gotoPath = continueUrlPathMatch[1];
@@ -68,28 +71,39 @@
       try {
         // Try verifying the email
         console.log('Verification: applying oobCode');
-        // TODO: localize
 
         loadingState = $_('auth.verification.verifying');
         // applyActionCode DOES NOT trigger idTokenChanged
         await applyActionCode(oobCode);
 
-        // The .reload() call triggers an idTokenChanged event.
-        // We don't need to force-reload the token here, idTokenChanged
-        // will take care of that.
         console.log('Verification: Reloading user to trigger idTokenChanged');
-        await auth().currentUser?.reload();
+        if ($user) {
+          loadingState = $_('auth.verification.reloading');
+          // TODO: an edge case we're not handling here:
+          // if you're logged in into a different account from the
+          // account that you are verifying.
 
-        // Success handling is done by idTokenChanged in auth.ts
+          // If we're logged in, reload the user.
+          //
+          // The .reload() call triggers an idTokenChanged event.
+          // We don't need to force-reload the token here, idTokenChanged
+          // will take care of that.
+          await auth().currentUser?.reload();
 
-        // Note: it is not guaranteed here that the verification was fully synced to the token yet.
-        // In that case, we consider the account email as unverified locally.
-        // Thus, to prevent confusion with the "Resend Verification" button,
-        // we don't immediately redirect to /account here
-        // idTokenChanged will do the redirection.
-        if (gotoPath && gotoPath !== routes.ACCOUNT) {
-          console.log('Verification: Redirecting to continueUrl');
-          goto(gotoPath);
+          // Success handling is done by idTokenChanged in auth.ts
+
+          // Note: it is not guaranteed here that the verification was fully synced to the token yet.
+          // In that case, we consider the account email as unverified locally.
+          // Thus, to prevent confusion with the "Resend Verification" button,
+          // we don't immediately redirect to /account here
+          // idTokenChanged will do the redirection.
+          if (gotoPath && gotoPath !== routes.ACCOUNT) {
+            console.log('Verification: Redirecting to continueUrl');
+            goto(gotoPath);
+          }
+        } else {
+          notify.success(`${$_('auth.verification.success')} ${$_('auth.verification.sign-in')}`);
+          goto(routes.SIGN_IN);
         }
       } catch (ex) {
         if ($user && (await isEmailVerifiedAndTokenSynced())) {

--- a/src/routes/chat/+layout.svelte
+++ b/src/routes/chat/+layout.svelte
@@ -14,6 +14,7 @@
   import { removeDiacritics } from '$lib/util';
   import { onMount } from 'svelte';
   import { checkAndHandleUnverified } from '@/lib/api/auth';
+  import createSlug from '@/lib/util/createSlug';
 
   let localPage = $page;
   // Subscribe to page is necessary to render the chat page of the selected chat (when the url changes) for mobile
@@ -51,22 +52,18 @@
     }
     await checkAndHandleUnverified($_('chat.notify.unverified'));
 
-    if (localPage.url.searchParams.get('with')) {
-      startChattingWith(localPage.url.searchParams.get('with'));
+    let withQueryParam = localPage.url.searchParams.get('with');
+    if (withQueryParam) {
+      startChattingWith(withQueryParam);
     }
   });
 
   // Functions
   const sortByLastActivity = (c1, c2) => c2.lastActivity - c1.lastActivity;
 
-  const getConvoRoute = (name, id) => `${routes.CHAT}/${normalizeName(name)}/${id}`;
+  const getConvoRoute = (name, id) => `${routes.CHAT}/${createSlug(name)}/${id}`;
 
-  const normalizeName = (name: string) => {
-    const parts = name.split(/[^A-Za-z-]/);
-    return removeDiacritics(parts[0]).toLowerCase();
-  };
-
-  const startChattingWith = async (partnerId) => {
+  const startChattingWith = async (partnerId: string) => {
     if ($chats) {
       const activeChatWithUser = getChatForUser(partnerId);
       if (activeChatWithUser) {

--- a/src/routes/garden/manage/+page.svelte
+++ b/src/routes/garden/manage/+page.svelte
@@ -8,10 +8,16 @@
   import { updateGarden } from '$lib/api/garden';
   import Form from '$lib/components/Garden/Form.svelte';
   import routes from '$lib/routes';
+  import { checkAndHandleUnverified } from '@/lib/api/auth';
 
-  if (!$user || !$user.emailVerified) {
-    notify.warning('Please verify your email first.', 8000);
-    goto(routes.ACCOUNT);
+  if (!$user) {
+    notify.info($_('auth.unsigned'), 8000);
+    goto(routes.SIGN_IN);
+  } else if (!$user.emailVerified) {
+    checkAndHandleUnverified($_('auth.verification.unverified'), 8000);
+  } else if (!$user.garden) {
+    notify.warning($_('garden.manage.add-first'));
+    goto(routes.ADD_GARDEN);
   }
   let updatingGarden = false;
 
@@ -45,4 +51,6 @@
 
 <Progress active={updatingGarden} />
 
-<Form on:submit={submit} isUpdate isSubmitting={updatingGarden} garden={$user.garden} />
+{#if $user && $user.garden}
+  <Form on:submit={submit} isUpdate isSubmitting={updatingGarden} garden={$user.garden} />
+{/if}

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -11,11 +11,53 @@
   import { TextInput, Progress, Button } from '$lib/components/UI';
   import { lockIcon, emailIcon, userIcon, flagIcon } from '$lib/images/icons';
   import { SUPPORT_EMAIL } from '$lib/constants';
+  import { AuthErrorCodes } from 'firebase/auth';
+  import isFirebaseError from '@/lib/util/types/isFirebaseError';
 
-  let fields = {
+  type FieldCommon = {
+    /**
+     * Populated by value validation. When error equals the empty string, there is no error,
+     * and the value can be considered valid.
+     */
+    error?: string;
+  };
+
+  type TextInputField = FieldCommon & {
+    /**
+     * Populated by a binding to an input.
+     */
+    value?: string;
+    /**
+     * Validates the value of this input field.
+     */
+    validate: (value: string | undefined) => string | undefined;
+  };
+
+  type CheckboxField = FieldCommon & {
+    /**
+     * Populated by a binding to an input.
+     */
+    value?: boolean;
+    /**
+     * Validates the value of this input field.
+     */
+    validate: (value: boolean | undefined) => string | undefined;
+  };
+
+  type RegistrationFields =
+    // Text inputs
+    {
+      [fieldName in 'email' | 'password' | 'firstName' | 'lastName' | 'country']: TextInputField;
+    } & { consent: CheckboxField }; // Checkbox fields
+
+  let fields: RegistrationFields = {
     email: {
       validate: (v) => {
-        if (!v) return $_('register.validate.email');
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#basic_validation
+        // NOTE: the value of the type="email" field seems to be trimmed by the browser.
+        const emailRegex =
+          /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+        if (!v || !emailRegex.test(v)) return $_('register.validate.email');
       }
     },
     password: {
@@ -28,14 +70,15 @@
     },
     firstName: {
       validate: (v) => {
-        if (!v) return $_('register.validate.first-name.set');
+        if (!v || v.trim() === '') return $_('register.validate.first-name.set');
         if (v.length > 25) return $_('register.validate.first-name.max');
       }
     },
     lastName: {
       validate: (v) => {
-        if (!v) return $_('register.validate.last-name');
+        if (!v || v.trim() === '') return $_('register.validate.last-name');
       }
+      // TODO: why is there no max-length constraint on last-name?
     },
     country: {
       validate: (v) => {
@@ -49,12 +92,12 @@
       }
     }
   };
-  let countryCode;
-  let countryInput;
+  let countryCode: string;
+  const countryCodes = Object.keys(countries) as (keyof typeof countries)[];
 
-  const validateCountry = (v) => {
+  const validateCountry = (v?: string) => {
     const value = v ? v.toLowerCase() : v;
-    const code = Object.keys(countries).find((key) => countries[key].toLowerCase() === value);
+    const code = countryCodes.find((key) => countries[key].toLowerCase() === value);
     if (!code) {
       const error = $_('register.validate.country.from-list');
       fields.country.error = error;
@@ -68,35 +111,43 @@
   let formError = '';
 
   const submit = async () => {
-    const errors = Object.keys(fields).reduce((all, field) => {
-      const error = fields[field].validate(fields[field].value);
-      fields[field].error = error || '';
-      if (error) all.push(error);
-      return all;
-    }, []);
+    // Validate all fields
+    let errorCount = 0;
+    (Object.keys(fields) as (keyof typeof fields)[]).forEach((fieldName) => {
+      const field = fields[fieldName];
+      // Type narrowing takes out the common "undefined" as the only possible type for v.
+      // We know the validation function is able to handle its own input
+      const error = (field.validate as (v: string | boolean | undefined) => string | undefined)(
+        field.value
+      );
+      fields[fieldName].error = error || '';
+      if (error) errorCount++;
+    });
 
     const error = validateCountry(fields.country.value);
-    if (error) errors.push(error);
+    if (error) errorCount++;
 
     fields = fields;
-    if (errors.length > 0) {
-      console.log(errors);
+    if (errorCount > 0) {
+      // Cancel submission
       return;
     }
 
     try {
       await register({
-        email: fields.email.value,
-        password: fields.password.value,
-        firstName: fields.firstName.value,
-        lastName: fields.lastName.value,
+        // We know that these fields are validated.
+        email: fields.email.value as string,
+        password: fields.password.value as string,
+        firstName: fields.firstName.value as string,
+        lastName: fields.lastName.value as string,
         countryCode
       });
       notify.success($_('register.notify.successful'), 10000);
       goto(routes.MAP);
-    } catch (err) {
+    } catch (err: unknown) {
       isRegistering.set(false);
-      if (err.code === 'auth/email-already-in-use') formError = $_('register.notify.in-use');
+      if (isFirebaseError(err) && err.code === AuthErrorCodes.EMAIL_EXISTS)
+        formError = $_('register.notify.in-use');
       else formError = $_('register.notify.unexpected', { values: { support: SUPPORT_EMAIL } });
       console.log(err);
     }
@@ -121,8 +172,11 @@
 
 <AuthContainer>
   <span slot="title">{$_('register.title')}</span>
-
-  <form on:submit|preventDefault={submit} slot="form">
+  <!--
+    Switch off built-in form validation (we implement our own)
+    https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#a_more_detailed_example
+  -->
+  <form novalidate on:submit|preventDefault={submit} slot="form">
     <div>
       <label for="first-name">{$_('register.first-name')}</label>
       <TextInput
@@ -159,6 +213,7 @@
         type="email"
         name="email"
         id="email"
+        required
         on:blur={() => {
           fields.email.error = '';
         }}
@@ -193,17 +248,10 @@
         bind:value={fields.country.value}
       />
       <datalist id="countries">
-        {#each Object.keys(countries) as code}
+        {#each countryCodes as code}
           <option data-value={code}>{countries[code]}</option>
         {/each}
       </datalist>
-      <input
-        type="hidden"
-        name="country"
-        id="country-hidden"
-        value={countryCode}
-        bind:this={countryInput}
-      />
     </div>
     <div class="consent">
       <div class="checkbox">

--- a/tests/e2e/test.ts
+++ b/tests/e2e/test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test';
+
+test('index page has expected h1', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('h1')).toContainText(['', 'Your slow travel adventure starts here']);
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('index page has expected h1', async ({ page }) => {
-  await page.goto('/');
-  await expect(page.locator('h1')).toContainText(['', 'Welcome To My Garden']);
-});

--- a/tests/unit/firestore-rules.test.ts
+++ b/tests/unit/firestore-rules.test.ts
@@ -1,0 +1,215 @@
+// Based on https://github.com/firebase/quickstart-testing/blob/master/unit-test-security-rules-v9/test/firestore.spec.js
+// Guide: https://firebase.google.com/docs/rules/unit-tests
+
+// Start emulators before executing tests.
+
+import { readFileSync, createWriteStream } from 'fs';
+import http from 'http';
+
+import {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+  type RulesTestEnvironment
+} from '@firebase/rules-unit-testing';
+
+import { doc, serverTimestamp, setDoc, setLogLevel, updateDoc } from 'firebase/firestore';
+import type firebase from 'firebase/compat/app';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  // Silence expected rules rejections from Firestore SDK. Unexpected rejections
+  // will still bubble up and will be thrown as an error (failing the tests).
+  setLogLevel('error');
+
+  const rules = readFileSync('firestore.rules', 'utf8');
+  testEnv = await initializeTestEnvironment({
+    projectId: 'demo-test',
+    firestore: {
+      host: '127.0.0.1',
+      port: 8080,
+      rules
+    }
+  });
+});
+
+afterAll(async () => {
+  // Delete all the FirebaseApp instances created during testing.
+  // Note: this does not affect or clear any data.
+  await testEnv.cleanup();
+
+  // Write the coverage report to a file
+  const coverageFile = 'firestore-coverage.html';
+  const fstream = createWriteStream(coverageFile);
+  await new Promise((resolve, reject) => {
+    if (!testEnv.emulators.firestore) {
+      throw new Error('Test emulator API not online');
+    }
+    const { host, port } = testEnv.emulators.firestore;
+    const quotedHost = host.includes(':') ? `[${host}]` : host;
+    http.get(
+      `http://${quotedHost}:${port}/emulator/v1/projects/${testEnv.projectId}:ruleCoverage.html`,
+      (res) => {
+        res.pipe(fstream, { end: true });
+
+        res.on('end', resolve);
+        res.on('error', reject);
+      }
+    );
+  });
+
+  console.log(`View firestore rule coverage information at ${coverageFile}\n`);
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+describe('registration', async () => {
+  it('should not allow an authenticated user to create their own "user" or "user-private" docs', async () => {
+    const aliceDb = testEnv.authenticatedContext('alice').firestore();
+
+    await assertFails(
+      setDoc(doc(aliceDb, 'users/alice'), {
+        firstName: 'Alice',
+        countryCode: 'BE'
+      })
+    );
+
+    await assertFails(setDoc(doc(aliceDb, 'users-private/alice'), {}));
+  });
+});
+
+const createAliceUser = async () => {
+  const aliceDb = testEnv.authenticatedContext('alice').firestore();
+
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    // This can only be called once.
+    const firestore = context.firestore();
+    await setDoc(doc(firestore, 'users/alice'), {
+      firstName: 'Kim',
+      countryCode: 'DE',
+      superfan: false
+    });
+
+    await setDoc(doc(firestore, 'users-private/alice'), {
+      lastName: 'Frazier',
+      consentedAt: serverTimestamp(),
+      emailPreferences: {
+        newChat: true,
+        news: true
+      }
+    });
+  });
+
+  return aliceDb;
+};
+
+describe('"user" data', async () => {
+  let testDb: firebase.firestore.Firestore;
+  beforeEach(async () => {
+    testDb = await createAliceUser();
+  });
+  it('should allow ONLY signed in users to update their users document with (a) required field', async () => {
+    await assertSucceeds(
+      updateDoc(doc(testDb, 'users/alice'), {
+        firstName: 'Alice',
+        countryCode: 'BE'
+      })
+    );
+  });
+
+  it('should allow ONLY signed in users to overwrite their doc with all required fields', async () => {
+    await assertSucceeds(
+      setDoc(doc(testDb, 'users/alice'), {
+        firstName: 'Alice',
+        countryCode: 'BE',
+        // "superfan: false" does not lead to a change
+        superfan: false
+      })
+    );
+
+    // Missing countryCode & superfan field
+    await assertFails(
+      setDoc(doc(testDb, 'users/alice'), {
+        firstName: 'Alice'
+      })
+    );
+  });
+
+  it('should NOT allow a user to change their superfan status', async () => {
+    await assertFails(
+      updateDoc(doc(testDb, 'users/alice'), {
+        superfan: true
+      })
+    );
+  });
+
+  it('fails when user docs are updated with invalid data', async () => {
+    await assertFails(
+      updateDoc(doc(testDb, 'users/alice'), {
+        firstName: null,
+        countryCode: null
+      })
+    );
+  });
+});
+
+describe('"user-private" data', async () => {
+  let testDb: firebase.firestore.Firestore;
+  beforeEach(async () => {
+    testDb = await createAliceUser();
+  });
+  it('fails when trying to create a document (firebase-admin required) ', async () => {
+    await assertFails(setDoc(doc(testDb, 'users-private/bob'), {}));
+  });
+  it('fails on overwrite when the basic field requirements are met', async () => {
+    await assertFails(
+      setDoc(doc(testDb, 'users-private/alice'), {
+        lastName: 'Frazier',
+        consentedAt: serverTimestamp(),
+        emailPreferences: {
+          // missing newChat
+          news: true
+        }
+      })
+    );
+  });
+  it('succeeds on overwrite when the basic field requirements are met', async () => {
+    await assertSucceeds(
+      setDoc(doc(testDb, 'users-private/alice'), {
+        lastName: 'Frazier',
+        consentedAt: serverTimestamp(),
+        emailPreferences: {
+          newChat: true,
+          news: true
+        }
+      })
+    );
+  });
+  it('fails on update when lastName is empty', async () => {
+    await assertFails(
+      updateDoc(doc(testDb, 'users-private/alice'), {
+        lastName: ''
+      })
+    );
+  });
+  it('disallows setting a Stripe customer ID', async () => {
+    await assertFails(
+      updateDoc(doc(testDb, 'users-private/alice'), {
+        stripeCustomerId: 'superCustomer'
+      })
+    );
+  });
+  it('disallows setting Stripe subscription details', async () => {
+    await assertFails(
+      updateDoc(doc(testDb, 'users-private/alice'), {
+        stripeSubscription: {
+          priceId: '123'
+        }
+      })
+    );
+  });
+});

--- a/tests/unit/strings.test.ts
+++ b/tests/unit/strings.test.ts
@@ -1,0 +1,20 @@
+import { removeDiacritics } from '@/lib/util';
+import createSlug from '@/lib/util/createSlug';
+import { describe, expect, it } from 'vitest';
+
+describe('removeDiacritics', () => {
+  it('leaves spaces, dashes and capital letters intact', () => {
+    const names = 'Bon-Jacques et Marie';
+    expect(removeDiacritics(names)).toBe(names);
+  });
+
+  it('Removes diacritics on characters', () => {
+    expect(removeDiacritics('Bon-Jâcques ét Marie ça vå')).toBe('Bon-Jacques et Marie ca va');
+  });
+});
+
+describe('createSlug', () => {
+  it('works', () => {
+    expect(createSlug('Jardin de Bon-Jâcques ét Marie')).toBe('jardin-de-bon-jacques-et-marie');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
+/// <reference types="vitest" />
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+
 import { defineConfig } from 'vite';
 import { createAvailableLocales } from './plugins/available-locales';
 import { customSvgLoader } from './plugins/svg-loader';
@@ -11,6 +13,11 @@ export default defineConfig((): UserConfig => {
     build: {
       minify: isProduction
     },
-    plugins: [createAvailableLocales(), customSvgLoader({ removeSVGTagAttrs: false }), sveltekit()]
+    plugins: [createAvailableLocales(), customSvgLoader({ removeSVGTagAttrs: false }), sveltekit()],
+    test: {
+      // Modified from
+      // https://vitest.dev/config/#include
+      include: ['tests/unit/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
+    }
   };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -461,6 +461,13 @@
     "@firebase/util" "1.8.0"
     tslib "^2.1.0"
 
+"@firebase/rules-unit-testing@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@firebase/rules-unit-testing/-/rules-unit-testing-2.0.5.tgz#bad9b500b7a879fc0ce41468f8e0c00d1bda7d8c"
+  integrity sha512-EV9YgbpfdUSA65aHBX/wkqKJbORrA9UmBNLRZxUsIWbHu9W8GE8Jvlb0uxU02iR+GpGW69zw+ZENANdRW3ZUMA==
+  dependencies:
+    node-fetch "2.6.7"
+
 "@firebase/storage-compat@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.2.0.tgz#3f3356e9f1131f8d98d8dca1639357ea918939d5"
@@ -1920,6 +1927,18 @@
     "@turf/invariant" "^6.5.0"
     d3-voronoi "1.1.2"
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
+  integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
+
 "@types/cookie@^0.5.1":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.5.1.tgz#b29aa1f91a59f35e29ff8f7cb24faf1a3a750554"
@@ -2079,15 +2098,61 @@
     "@typescript-eslint/types" "5.48.1"
     eslint-visitor-keys "^3.3.0"
 
+"@vitest/expect@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-0.28.2.tgz#375af32579b3d6b972a1fe0be0e0260ffb84bc7d"
+  integrity sha512-syEAK7I24/aGR2lXma98WNnvMwAJ+fMx32yPcj8eLdCEWjZI3SH8ozMaKQMy65B/xZCZAl6MXmfjtJb2CpWPMg==
+  dependencies:
+    "@vitest/spy" "0.28.2"
+    "@vitest/utils" "0.28.2"
+    chai "^4.3.7"
+
+"@vitest/runner@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.28.2.tgz#671c8f489ceac2bcf1bc2d993f9920da10347d3f"
+  integrity sha512-BJ9CtfPwWM8uc5p7Ty0OprwApyh8RIaSK7QeQPhwfDYA59AAE009OytqA3aX0yj1Qy5+k/mYFJS8RJZgsueSGA==
+  dependencies:
+    "@vitest/utils" "0.28.2"
+    p-limit "^4.0.0"
+    pathe "^1.1.0"
+
+"@vitest/spy@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-0.28.2.tgz#74d970601eebc41d48e685323b2853b2c88f8db4"
+  integrity sha512-KlLzTzi5E6tHcI12VT+brlY1Pdi7sUzLf9+YXgh80+CfLu9DqPZi38doBBAUhqEnW/emoLCMinPMMoJlNAQZXA==
+  dependencies:
+    tinyspy "^1.0.2"
+
+"@vitest/utils@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-0.28.2.tgz#2d79de7afb44e821a2c7e692bafb40d2cf765bb7"
+  integrity sha512-wcVTNnVdr22IGxZHDgiXrxWYcXsNg0iX2iBuOH3tVs9eme6fXJ0wxjn0/gCpp0TofQSoUwo3tX8LNACFVseDuA==
+  dependencies:
+    cli-truncate "^3.1.0"
+    diff "^5.1.0"
+    loupe "^2.3.6"
+    picocolors "^1.0.0"
+    pretty-format "^27.5.1"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^8.8.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
+
+acorn@^8.8.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -2104,12 +2169,27 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 anymatch@~3.1.2:
   version "3.1.3"
@@ -2128,6 +2208,11 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2164,12 +2249,22 @@ buffer-crc32@^0.2.5:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 busboy@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
   integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
   dependencies:
     streamsearch "^1.1.0"
+
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
 call-bind@^1.0.2:
   version "1.0.2"
@@ -2184,6 +2279,19 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+chai@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -2191,6 +2299,11 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 chokidar@^3.4.1:
   version "3.5.3"
@@ -2217,6 +2330,14 @@ cli-color@^2.0.3:
     es6-iterator "^2.0.3"
     memoizee "^0.4.15"
     timers-ext "^0.1.7"
+
+cli-truncate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -2310,6 +2431,13 @@ debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-equal@1.x, deep-equal@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -2355,6 +2483,11 @@ devalue@^4.2.0:
   resolved "https://registry.yarnpkg.com/devalue/-/devalue-4.2.1.tgz#5dcd17d7f443d79441da6cb8d9ed0419873c5e1a"
   integrity sha512-YBJUuWIDFor9zhRQJguMjvzBC4cUjZXgebcmCQO/Va4RLQ1b33+JKXJapOyuaHGW8Y986ygKyXQvR3LlOonLow==
 
+diff@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -2379,10 +2512,20 @@ earcut@^2.0.0, earcut@^2.2.4:
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
   integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -2781,6 +2924,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
@@ -3005,6 +3153,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -3081,6 +3234,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonc-parser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+
 kdbush@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
@@ -3113,6 +3271,11 @@ loader-utils@^1.1.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+local-pkg@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
+  integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -3139,6 +3302,13 @@ long@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.1.tgz#e27595d0083d103d2fa2c20c7699f8e0c92b897f"
   integrity sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==
+
+loupe@^2.3.1, loupe@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3252,6 +3422,16 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+mlly@^1.0.0, mlly@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.1.0.tgz#9e23c5e675ef7b10cc47ee6281795cb1a7aa3aa2"
+  integrity sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==
+  dependencies:
+    acorn "^8.8.1"
+    pathe "^1.0.0"
+    pkg-types "^1.0.1"
+    ufo "^1.0.1"
+
 mri@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -3353,6 +3533,13 @@ p-limit@^3.0.2:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
@@ -3392,6 +3579,16 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^1.0.0, pathe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.0.tgz#e2e13f6c62b31a3289af4ba19886c230f295ec03"
+  integrity sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 pbf@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.2.1.tgz#b4c1b9e72af966cd82c6531691115cc0409ffe2a"
@@ -3409,6 +3606,15 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+pkg-types@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.0.1.tgz#25234407f9dc63409af45ced9407625ff446a761"
+  integrity sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==
+  dependencies:
+    jsonc-parser "^3.2.0"
+    mlly "^1.0.0"
+    pathe "^1.0.0"
 
 playwright-core@1.29.2:
   version "1.29.2"
@@ -3455,6 +3661,15 @@ prettier@^2.6.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.2.tgz#c4ea1b5b454d7c4b59966db2e06ed7eec5dfd160"
   integrity sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==
+
+pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 protobufjs@^6.11.3:
   version "6.11.3"
@@ -3531,6 +3746,11 @@ rbush@^3.0.1:
   integrity sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==
   dependencies:
     quickselect "^2.0.0"
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -3663,6 +3883,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 simple-html-tokenizer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
@@ -3687,6 +3912,14 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
+
 smoothscroll-polyfill@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
@@ -3707,6 +3940,19 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 sourcemap-codec@^1.3.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
@@ -3716,6 +3962,16 @@ splaytree@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.1.tgz#e1bc8e68e64ef5a9d5f09d36e6d9f3621795a438"
   integrity sha512-9FaQ18FF0+sZc/ieEeXHt+Jw2eSpUgUtTLDYB/HXKWvhYVyOc7h1hzkn5MMO3GPib9MmXG1go8+OsBBzs/NMww==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.3.1.tgz#93a81835815e618c8aa75e7c8a4dc04f7c314e29"
+  integrity sha512-3H20QlwQsSm2OvAxWIYhs+j01MzzqwMwGiiO1NQaJYZgJZFPuAbf95/DiKRBSTYIJ2FeGUc+B/6mPGcWP9dO3Q==
 
 streamsearch@^1.1.0:
   version "1.1.0"
@@ -3731,12 +3987,28 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string-width@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -3749,6 +4021,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-literal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-1.0.0.tgz#0a484ed5a978cd9d2becf3cf8f4f2cb5ab0e1e74"
+  integrity sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==
+  dependencies:
+    acorn "^8.8.1"
 
 supercluster@^7.1.5:
   version "7.1.5"
@@ -3854,10 +4133,25 @@ tiny-glob@^0.2.9:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
+tinybench@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
+  integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
+
+tinypool@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.0.tgz#c405d8b743509fc28ea4ca358433190be654f819"
+  integrity sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==
+
 tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
   integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
+
+tinyspy@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.2.tgz#6da0b3918bfd56170fb3cd3a2b5ef832ee1dff0d"
+  integrity sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -3919,6 +4213,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -3939,6 +4238,11 @@ typescript@^4.9.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
+ufo@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.0.1.tgz#64ed43b530706bda2e4892f911f568cf4cf67d29"
+  integrity sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==
+
 uic-codes@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/uic-codes/-/uic-codes-0.3.0.tgz#dc4470e2164422ea68154ac621d63de8a82755e8"
@@ -3958,7 +4262,21 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-vite@^4.0.4:
+vite-node@0.28.2:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.2.tgz#58b52fc638f86fee9bfe4990abaea7e4d74f6514"
+  integrity sha512-zyiJ3DLs9zXign4P2MD4PQk+7rdT+JkHukgmmS0KuImbCQ7WnCdea5imQVeT6OtUsBwsLztJxQODUsinVr91tg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    mlly "^1.1.0"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
+    source-map "^0.6.1"
+    source-map-support "^0.5.21"
+    vite "^3.0.0 || ^4.0.0"
+
+"vite@^3.0.0 || ^4.0.0", vite@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.0.4.tgz#4612ce0b47bbb233a887a54a4ae0c6e240a0da31"
   integrity sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==
@@ -3974,6 +4292,36 @@ vitefu@^0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/vitefu/-/vitefu-0.2.4.tgz#212dc1a9d0254afe65e579351bed4e25d81e0b35"
   integrity sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==
+
+vitest@^0.28.2:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.28.2.tgz#952e1ad83fbd04ee1bfce634b106a371a5973603"
+  integrity sha512-HJBlRla4Mng0OiZ8aWunCecJ6BzLDA4yuzuxiBuBU2MXjGB6I4zT7QgIBL/UrwGKlNxLwaDC5P/4OpeuTlW8yQ==
+  dependencies:
+    "@types/chai" "^4.3.4"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    "@vitest/expect" "0.28.2"
+    "@vitest/runner" "0.28.2"
+    "@vitest/spy" "0.28.2"
+    "@vitest/utils" "0.28.2"
+    acorn "^8.8.1"
+    acorn-walk "^8.2.0"
+    cac "^6.7.14"
+    chai "^4.3.7"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
+    source-map "^0.6.1"
+    std-env "^3.3.1"
+    strip-literal "^1.0.0"
+    tinybench "^2.3.1"
+    tinypool "^0.3.0"
+    tinyspy "^1.0.2"
+    vite "^3.0.0 || ^4.0.0"
+    vite-node "0.28.2"
+    why-is-node-running "^2.2.2"
 
 vt-pbf@^3.1.3:
   version "3.1.3"
@@ -4024,6 +4372,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.2.2.tgz#4185b2b4699117819e7154594271e7e344c9973e"
+  integrity sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.3:
   version "1.2.3"
@@ -4076,3 +4432,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==


### PR DESCRIPTION
- Small Firestore rule restructuring
- build: add VSCode tasks.json
- docs: mention Conventional Commits
- fix: clarify "users" & "users-private" Firebase types
- docs: adds some clarifications & ideas
- fix: tighten users & users-private firestore rules
- test: add Vitest & firestore rules unit tests
- fix: tighten validation and complete TS types in the /register page
- feat: log URLs to help with local email verification debugging
- fix: improve verification handling between independent windows
- build: discard unnecesary window for installing demo-test env
- fix: make the slug generator for chats more reliable
- chore(release): bump version for release
