### PR TITLE
fix: rerun `firebase init hosting:github`

### DIFF
--- a/.github/workflows/firebase-hosting-merge-staging.yml
+++ b/.github/workflows/firebase-hosting-merge-staging.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_STAGING }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_DEV }}'
           projectId: wtmg-dev
           channelId: live
           target: beta

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -31,6 +31,6 @@ jobs:
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_STAGING }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_DEV }}'
           projectId: wtmg-dev
           target: beta

--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,11 @@
     {
       "target": "production",
       "public": "dist",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
       "rewrites": [
         {
           "source": "**",
@@ -14,7 +18,11 @@
     {
       "target": "beta",
       "public": "dist",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
       "rewrites": [
         {
           "source": "**",
@@ -25,7 +33,9 @@
   ],
   "functions": {
     "source": "api",
-    "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run lint"]
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run lint"
+    ]
   },
   "emulators": {
     "functions": {


### PR DESCRIPTION
I had deleted Service Account key IDs that I couldn't recognize, one of those must have been the old `secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_STAGING`. Regenerating with wtmg-dev logged in generated _DEV instead. Not sure how to get back _STAGING (or if that's even desirable). This should work!
