### PR TITLE
feat/announcement copy

### DIFF
--- a/src/lib/components/Nav/Mobile/MobileNav/SideDrawer.svelte
+++ b/src/lib/components/Nav/Mobile/MobileNav/SideDrawer.svelte
@@ -12,7 +12,8 @@
   import { createEventDispatcher } from 'svelte';
   import { COMMUNITY_FORUM_URL, DONATION_URL } from '$lib/constants';
   import NewBadge from '../../NewBadge.svelte';
-  import { anchorText, membershipBlogLink } from '$lib/util/translation-helpers';
+  import { anchorText } from '$lib/util/translation-helpers';
+  import createUrl from '$lib/util/create-url';
 
   const dispatch = createEventDispatcher();
   export let isOpen = false;
@@ -70,12 +71,13 @@
         >{@html $_('navigation.membership-notice.answer', {
           values: {
             linkText: anchorText({
-              href: membershipBlogLink($_, {
+              href: createUrl(routes.ABOUT_MEMBERSHIP, {
                 utm_campaign: 'membership_announcement_jun_23',
                 utm_content: 'side_navbar'
               }),
               linkText: $_('navigation.membership-notice.link-text'),
-              style: 'text-decoration: underline; cursor: pointer;'
+              style: 'text-decoration: underline; cursor: pointer;',
+              newtab: false
             })
           }
         })}</span

--- a/src/lib/components/Nav/Top/TopNav.svelte
+++ b/src/lib/components/Nav/Top/TopNav.svelte
@@ -7,7 +7,8 @@
   import WtmgLogo from '../../UI/WTMGLogo.svelte';
   import { COMMUNITY_FORUM_URL } from '$lib/constants';
   import NewBadge from '../NewBadge.svelte';
-  import { anchorText, membershipBlogLink } from '$lib/util/translation-helpers';
+  import { anchorText } from '$lib/util/translation-helpers';
+  import createUrl from '$lib/util/create-url';
 
   $: firstName = $user ? $user.firstName : '';
 </script>
@@ -20,12 +21,13 @@
         >{@html $_('navigation.membership-notice.answer', {
           values: {
             linkText: anchorText({
-              href: membershipBlogLink($_, {
+              href: createUrl(routes.ABOUT_MEMBERSHIP, {
                 utm_campaign: 'membership_announcement_jun_23',
                 utm_content: 'top_navbar'
               }),
               linkText: $_('navigation.membership-notice.link-text'),
-              style: 'text-decoration: underline; cursor: pointer;'
+              style: 'text-decoration: underline; cursor: pointer;',
+              newtab: false
             })
           }
         })}

--- a/src/lib/util/create-url.ts
+++ b/src/lib/util/create-url.ts
@@ -1,0 +1,9 @@
+import { mapValues } from 'lodash-es';
+
+/**
+ * @param base the URL + path, excluding query parameters
+ */
+export default (base: string, queryParams: Record<string, string | number | boolean>) => {
+  const searchParams = new URLSearchParams(mapValues(queryParams, (v) => v.toString()));
+  return `${base}?${searchParams.toString()}`;
+};

--- a/src/lib/util/translation-helpers.ts
+++ b/src/lib/util/translation-helpers.ts
@@ -4,6 +4,7 @@ import type { _ } from 'svelte-i18n';
 type Flatten<T> = T extends Readable<infer U> ? U : T;
 export type MessageFormatter = Flatten<typeof _>;
 import { WTMG_BLOG_BASE_URL } from '$lib/constants';
+import createUrl from './create-url';
 
 export const anchorText = (props: {
   href: string;
@@ -45,7 +46,6 @@ export const membershipBlogLink = (
     ...(utm_campaign ? { utm_campaign } : { utm_campaign: 'membership' }),
     ...(utm_content ? { utm_content } : undefined)
   };
-  return `${WTMG_BLOG_BASE_URL}${t('generics.fair-model-blog-path')}?${new URLSearchParams(
-    params
-  ).toString()}`;
+
+  return createUrl(`${WTMG_BLOG_BASE_URL}${t('generics.fair-model-blog-path')}`, params);
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,8 +42,8 @@
   "navigation": {
     "membership-notice": {
       "prompt": "New: ",
-      "answer": "a WTMG membership for all slow travellers. Find out more in {linkText}!",
-      "link-text": "this blog post"
+      "answer": "a WTMG membership for all slow travellers. Find out more {linkText}!",
+      "link-text": "here"
     }
   },
   "index": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -36,8 +36,8 @@
   "navigation": {
     "membership-notice": {
       "prompt": "Nouveau : ",
-      "answer": "une adhésion WTMG pour tous les voyageurs lents. Pour en savoir plus, {linkText}.",
-      "link-text": "lisez ce blog post"
+      "answer": "une adhésion WTMG pour tous les voyageurs lents. Pour en savoir plus, {linkText}",
+      "link-text": "cliquez ici !"
     }
   },
   "index": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -34,8 +34,8 @@
   "navigation": {
     "membership-notice": {
       "prompt": "Nieuw: ",
-      "answer": "een WTMG-lidmaatschap voor alle trage reizigers. Lees er meer over in {linkText}!",
-      "link-text": "deze blogpost"
+      "answer": "een WTMG-lidmaatschap voor alle trage reizigers. Lees er {linkText} meer over!",
+      "link-text": "hier"
     }
   },
   "index": {


### PR DESCRIPTION
- refactor: utility function for creating URLs w/ query params
- copy: makes the membership announcement go to the /about-membership page
