### PR TITLE
Issue #287 : Support sending a chat message with a keyboard shortcut 

### DIFF
--- a/src/routes/(stateful)/chat/[name]/[chatId]/+page.svelte
+++ b/src/routes/(stateful)/chat/[name]/[chatId]/+page.svelte
@@ -22,7 +22,7 @@
   import { NOTIFICATION_PROMPT_DISMISSED_COOKIE } from '$lib/constants';
   import { hasOrHadEnabledNotificationsSomewhere } from '$lib/api/push-registrations';
   import { isMobileDevice, uaInfo } from '$lib/util/uaInfo';
-  import { OS } from 'ua-parser-js/enums'
+  import { OS } from 'ua-parser-js/enums';
   import {
     canHaveNotificationSupport,
     hasNotificationSupportNow
@@ -314,12 +314,15 @@
     }
   };
 
-  const keydownHandler = (evt: KeyboardEvent) => {
+  const keydownHandler = async (evt: KeyboardEvent) => {
     const os = uaInfo.os;
     const modKey = [OS.MACOS, OS.IOS].includes(os.name) ? evt.metaKey : evt.ctrlKey;
     if (!modKey) return;
     if (evt.code === 'Enter') {
-      send();
+      await send();
+      // Disabled text areas can not be focused.
+      // Wait until the textArea is re-enabled at the end of send(), before trying to refocus it.
+      textArea?.focus();
     }
   };
 


### PR DESCRIPTION
Add keydown event to textarea which sends message.

UX question : now that you are able to send with a keyboard shortcut, it seems odd to lose focus of the text area. Is it necessary that the text area is disabled while the message is sending ? 