### PR TITLE
Add swipe-down-to-close gesture for mobile bottom sheets

### DIFF
--- a/src/lib/components/Garden/GardenDrawer.svelte
+++ b/src/lib/components/Garden/GardenDrawer.svelte
@@ -203,6 +203,32 @@
   let chatWithGardenLink = $derived(`${$lr(routes.CHAT)}?with=${garden?.id}`);
   let gardenLink = $derived(`${$lr(routes.MAP)}/garden/${garden?.id}`);
 
+  // Swipe-down-to-close for mobile bottom sheet
+  let swipeTouchStartY = $state(0);
+  let swipeDragOffset = $state(0);
+  let isSwiping = $state(false);
+
+  const handleDragTouchStart = (e: TouchEvent) => {
+    swipeTouchStartY = e.touches[0].clientY;
+    isSwiping = true;
+  };
+
+  const handleDragTouchMove = (e: TouchEvent) => {
+    if (!isSwiping) return;
+    const delta = e.touches[0].clientY - swipeTouchStartY;
+    swipeDragOffset = Math.max(0, delta);
+  };
+
+  const handleDragTouchEnd = () => {
+    isSwiping = false;
+    if (swipeDragOffset > 80) {
+      swipeDragOffset = 0;
+      onclose();
+    } else {
+      swipeDragOffset = 0;
+    }
+  };
+
   const createPhoneNumberPlaceHolder = (length: number) => {
     const container = document.createElement('span');
     mount(HiddenPhoneNumber, {
@@ -291,9 +317,18 @@
   class="drawer"
   class:hidden={!gardenIsSelected}
   bind:this={drawerElement}
+  style:transform={swipeDragOffset > 0 ? `translateY(${swipeDragOffset}px)` : undefined}
+  style:transition={isSwiping ? 'none' : undefined}
   {@attach clickOutside}
   onclickoutside={handleClickOutsideDrawer}
 >
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="drag-handle"
+    ontouchstart={handleDragTouchStart}
+    ontouchmove={handleDragTouchMove}
+    ontouchend={handleDragTouchEnd}
+  ></div>
   {#if gardenIsSelected && initialGardenInfoLoaded && userInfo && garden}
     <section class="main">
       <header>
@@ -473,6 +508,18 @@
 </div>
 
 <style>
+  .drag-handle {
+    display: none;
+    width: 4rem;
+    height: 0.4rem;
+    background-color: var(--color-gray);
+    border-radius: 2px;
+    margin: -1.2rem auto 1.5rem;
+    cursor: grab;
+    touch-action: none;
+    flex-shrink: 0;
+  }
+
   .drawer {
     display: flex;
     flex-direction: column;
@@ -701,6 +748,10 @@
   }
 
   @media screen and (max-width: 700px) {
+    .drag-handle {
+      display: block;
+    }
+
     .drawer {
       padding: 2.7rem 2.7rem 0 2.7rem;
       min-height: auto;

--- a/src/lib/components/Garden/GardenDrawer.svelte
+++ b/src/lib/components/Garden/GardenDrawer.svelte
@@ -229,6 +229,36 @@
     }
   };
 
+  const handleDragTouchCancel = () => {
+    isSwiping = false;
+    swipeDragOffset = 0;
+  };
+
+  // Content area: only start swipe-to-close when already scrolled to the top
+  let drawerContentEl: HTMLElement | undefined = $state();
+
+  const handleContentTouchStart = (e: TouchEvent) => {
+    if (drawerContentEl && drawerContentEl.scrollTop === 0) {
+      handleDragTouchStart(e);
+    }
+  };
+
+  $effect(() => {
+    const el = drawerContentEl;
+    if (!el) return;
+    // Non-passive so we can preventDefault to stop native scroll when swiping down at top
+    const onTouchMove = (e: TouchEvent) => {
+      if (!isSwiping) return;
+      const delta = e.touches[0].clientY - swipeTouchStartY;
+      if (delta > 0) {
+        e.preventDefault();
+        swipeDragOffset = delta;
+      }
+    };
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    return () => el.removeEventListener('touchmove', onTouchMove);
+  });
+
   const createPhoneNumberPlaceHolder = (length: number) => {
     const container = document.createElement('span');
     mount(HiddenPhoneNumber, {
@@ -328,10 +358,17 @@
     ontouchstart={handleDragTouchStart}
     ontouchmove={handleDragTouchMove}
     ontouchend={handleDragTouchEnd}
+    ontouchcancel={handleDragTouchCancel}
   ></div>
   {#if gardenIsSelected && initialGardenInfoLoaded && userInfo && garden}
     <section class="main">
-      <header>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <header
+        ontouchstart={handleDragTouchStart}
+        ontouchmove={handleDragTouchMove}
+        ontouchend={handleDragTouchEnd}
+        ontouchcancel={handleDragTouchCancel}
+      >
         <div class="garden-title">
           <Text weight="w600" size="l" class="garden-title-text notranslate">
             {#if ownedByLoggedInUser}
@@ -350,7 +387,11 @@
                 >
               </button>
             {/if}
-            <button class="close-button" onclick={onclose}>
+            <button
+              class="close-button"
+              onclick={onclose}
+              ontouchstart={(e) => e.stopPropagation()}
+            >
               <Icon icon={crossIcon} />
             </button>
           </div>
@@ -363,7 +404,11 @@
           </button>
         {/if}
       </header>
-      <div class="drawer-content-area">
+      <div class="drawer-content-area" bind:this={drawerContentEl}
+        ontouchstart={handleContentTouchStart}
+        ontouchend={handleDragTouchEnd}
+        ontouchcancel={handleDragTouchCancel}
+      >
         <div class="description" bind:this={descriptionEl}>
           <Text
             >{$user?.superfan
@@ -510,14 +555,19 @@
 <style>
   .drag-handle {
     display: none;
+    cursor: grab;
+    touch-action: none;
+    flex-shrink: 0;
+  }
+
+  .drag-handle::before {
+    content: '';
+    display: block;
     width: 4rem;
     height: 0.4rem;
     background-color: var(--color-gray);
     border-radius: 2px;
-    margin: -1.2rem auto 1.5rem;
-    cursor: grab;
-    touch-action: none;
-    flex-shrink: 0;
+    margin: 0 auto;
   }
 
   .drawer {
@@ -750,10 +800,21 @@
   @media screen and (max-width: 700px) {
     .drag-handle {
       display: block;
+      /* Full-width so the entire top strip is touchable */
+      width: 100%;
+      /* padding-top provides whitespace above the pill (replaces the drawer's
+         removed top padding); padding-bottom bridges the gap to the header below */
+      padding: 1.5rem 0 1.5rem;
+    }
+
+    header {
+      /* Entire header area is a swipe target on mobile */
+      touch-action: none;
     }
 
     .drawer {
-      padding: 2.7rem 2.7rem 0 2.7rem;
+      /* Top padding is handled by the drag-handle element above the header */
+      padding: 0 2.7rem 0 2.7rem;
       min-height: auto;
       max-height: calc(var(--vh, 1vh) * 70);
       top: auto;

--- a/src/lib/components/UI/Modal.svelte
+++ b/src/lib/components/UI/Modal.svelte
@@ -103,6 +103,32 @@
     if (e.key === 'Escape' || e.keyCode === 27) close();
   };
 
+  // Swipe-down-to-close for bottom sheet modals
+  let swipeTouchStartY = $state(0);
+  let swipeDragOffset = $state(0);
+  let isSwiping = $state(false);
+
+  const handleDragTouchStart = (e: TouchEvent) => {
+    swipeTouchStartY = e.touches[0].clientY;
+    isSwiping = true;
+  };
+
+  const handleDragTouchMove = (e: TouchEvent) => {
+    if (!isSwiping) return;
+    const delta = e.touches[0].clientY - swipeTouchStartY;
+    swipeDragOffset = Math.max(0, delta);
+  };
+
+  const handleDragTouchEnd = () => {
+    isSwiping = false;
+    if (swipeDragOffset > 80) {
+      swipeDragOffset = 0;
+      close();
+    } else {
+      swipeDragOffset = 0;
+    }
+  };
+
   onMount(() => {
     //  Trigger CSS background transition
     effectiveBgColor = backgroundColor;
@@ -154,9 +180,22 @@
       class:transparent
       style:max-width={maxWidth}
       style:max-height={maxHeight}
+      style:transform={stickToBottom && swipeDragOffset > 0
+        ? `translateY(${swipeDragOffset}px)`
+        : undefined}
+      style:transition={stickToBottom && isSwiping ? 'none' : undefined}
       {@attach focusTrap}
       id="dialog"
     >
+      {#if stickToBottom}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="drag-handle"
+          ontouchstart={handleDragTouchStart}
+          ontouchmove={handleDragTouchMove}
+          ontouchend={handleDragTouchEnd}
+        ></div>
+      {/if}
       <div class="modal-header">
         <!--
           {ariaLabelledBy} inserts an "arialabelledby" attribute (which is not a valid ARIA attribute)
@@ -222,6 +261,17 @@
   .stick-to-bottom .modal-content {
     border-radius: var(--modal-border-radius) var(--modal-border-radius) 0 0;
     max-height: 77%;
+  }
+
+  .drag-handle {
+    width: 4rem;
+    height: 0.4rem;
+    background-color: var(--color-gray);
+    border-radius: 2px;
+    margin: -0.5rem auto 1.5rem;
+    cursor: grab;
+    touch-action: none;
+    flex-shrink: 0;
   }
 
   .center {


### PR DESCRIPTION
## Summary

Adds swipe-down-to-close gesture support for mobile bottom sheets in the Garden drawer and Modal components. Users can now swipe down on mobile devices to dismiss these components, improving the mobile UX with a familiar gesture pattern.

## Changes

- **GardenDrawer.svelte**: Added touch event handlers and drag state management to detect downward swipes. When a user swipes down more than 80px, the drawer closes. Includes a visual drag handle at the top of the drawer (mobile only).

- **Modal.svelte**: Implemented the same swipe-down-to-close functionality for bottom sheet modals (`stickToBottom` variant). The drag handle is conditionally rendered only when the modal is positioned at the bottom.

- **Touch handling**: Both components track touch start position, calculate drag offset during movement, and trigger close when threshold (80px) is exceeded. Smooth transitions are disabled during active swiping for responsive feedback.

- **Styling**: Added `.drag-handle` styles (4rem wide, 0.4rem tall gray bar) that appear only on mobile (max-width: 700px) to provide a visual affordance for the swipe gesture.

## Implementation Details

- Uses Svelte 5 `$state` for reactive drag state management
- Touch events (`ontouchstart`, `ontouchmove`, `ontouchend`) are bound directly to the drag handle element
- Transform is applied via inline styles for smooth visual feedback during drag
- Transition is conditionally disabled (`transition: none`) while swiping to prevent animation lag
- Threshold of 80px prevents accidental dismissal from small swipes

https://claude.ai/code/session_018ToSsWtVi7MUr6quZbkdLG