### PR TITLE
Skip fly transitions on browser back-forward navigation

### DIFF
--- a/src/routes/[[lang]]/(stateful)/chat/+layout.svelte
+++ b/src/routes/[[lang]]/(stateful)/chat/+layout.svelte
@@ -3,6 +3,7 @@
   import { fly } from 'svelte/transition';
   import { flip } from 'svelte/animate';
   import { goto } from '$lib/util/navigate';
+  import { beforeNavigate } from '$app/navigation';
   import { page } from '$app/stores';
   import { getUser, user } from '$lib/stores/auth';
   import notify from '$lib/stores/notification';
@@ -35,6 +36,13 @@
   }
 
   let { children }: Props = $props();
+
+  // Track whether the current navigation is a browser/native back-forward (popstate).
+  // When true, we skip the Svelte fly transitions to avoid double-animation on native swipe-back.
+  let isPopstateNav = $state(false);
+  beforeNavigate(({ type }) => {
+    isPopstateNav = type === 'popstate';
+  });
 
   onMount(async () => {
     if (!$user) {
@@ -191,7 +199,7 @@
       <!-- Chat listing -->
       <section
         class="conversations"
-        in:fly={{ x: '-100%', duration: 400 }}
+        in:fly={isPopstateNav ? { duration: 0 } : { x: '-100%', duration: 400 }}
         class:is-mobile={isMobile()}
       >
         <h2>{$_('chat.all-conversations')}</h2>
@@ -230,7 +238,7 @@
     {/if}
     {#if !isMobile() || (isMobile() && !isOverview)}
       <!-- Specific opened chat -->
-      <div class="chat" in:fly={{ x: '100%', duration: 400 }}>
+      <div class="chat" in:fly={isPopstateNav ? { duration: 0 } : { x: '100%', duration: 400 }}>
         {@render children?.()}
       </div>
     {/if}


### PR DESCRIPTION
## Summary

Prevents double-animation when users navigate back/forward using browser or native swipe gestures by detecting popstate navigation and disabling Svelte fly transitions in those cases.

## Changes

- Import `beforeNavigate` from `$app/navigation` to detect navigation type
- Add `isPopstateNav` state to track whether current navigation is a browser/native back-forward (popstate)
- Update `beforeNavigate` hook to set `isPopstateNav = true` when navigation type is 'popstate'
- Conditionally apply fly transitions on the conversations and chat sections:
  - When `isPopstateNav` is true: use `{ duration: 0 }` (no animation)
  - Otherwise: use original fly animation `{ x: '100%'/'−100%', duration: 400 }`

## Implementation Details

The fix addresses a UX issue where Svelte's fly transitions would animate simultaneously with native browser/swipe-back animations, creating a jarring double-animation effect. By detecting popstate navigation (which indicates browser back-forward or native swipe gestures), we skip the Svelte transitions while preserving them for regular client-side navigation.

https://claude.ai/code/session_012DZ5WKCZTC42H9T3FNdLMN