### PR TITLE
feat(capacitor): native offline gate so the splash doesn't hang without internet

### DIFF
--- a/android/app/src/main/java/org/welcometomygarden/app/MainActivity.java
+++ b/android/app/src/main/java/org/welcometomygarden/app/MainActivity.java
@@ -1,5 +1,6 @@
 package org.welcometomygarden.app;
 
+import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 
@@ -8,6 +9,8 @@ import androidx.activity.EdgeToEdge;
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
+  private OfflineGate offlineGate;
+
   // Our web UI currently is not designed for wide screens with short height
   // like phones in landscape mode. Square-ish foldable inner screens are OK.
   private boolean canSupportLandscape() {
@@ -29,5 +32,26 @@ public class MainActivity extends BridgeActivity {
     // Enable edge-to-edge mode
     // see https://github.com/capacitor-community/safe-area
     EdgeToEdge.enable(this);
+
+    // Show a native offline screen (and recover automatically) if the remote site can't load
+    // because the device is offline at startup. See OfflineGate for details.
+    offlineGate = OfflineGate.attach(this, getBridge());
+  }
+
+  @Override
+  public void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    if (offlineGate != null) {
+      offlineGate.handleNewIntent(intent);
+    }
+  }
+
+  @Override
+  public void onDestroy() {
+    if (offlineGate != null) {
+      offlineGate.destroy();
+      offlineGate = null;
+    }
+    super.onDestroy();
   }
 }

--- a/android/app/src/main/java/org/welcometomygarden/app/OfflineGate.java
+++ b/android/app/src/main/java/org/welcometomygarden/app/OfflineGate.java
@@ -1,0 +1,313 @@
+package org.welcometomygarden.app;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Color;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkRequest;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import com.getcapacitor.Bridge;
+import com.getcapacitor.WebViewListener;
+
+/**
+ * Native "offline gate" for the Capacitor app.
+ *
+ * <p>In production the app uses Capacitor's {@code server.url} to load the remote website. The
+ * splash screen is configured with {@code launchAutoHide: false} and is only hidden once the remote
+ * site's JavaScript boots (see {@code src/routes/+layout.svelte}). When the device has no internet
+ * connection at startup, the remote site never loads, the JS never runs, and the splash screen stays
+ * on screen forever.
+ *
+ * <p>This class watches the initial WebView load. If the remote site cannot be reached because the
+ * device is offline, it shows a native, localized "needs an internet connection" overlay with a
+ * spinner, polls for connectivity, and reloads {@code server.url} as soon as the connection is
+ * restored. Deep links that arrive while offline are stored and re-applied on the reload.
+ *
+ * <p>Only relevant when a remote {@code server.url} is configured; on local/dev builds (no server
+ * url) the gate disables itself.
+ */
+public class OfflineGate {
+
+  /** Grace period before showing the offline overlay, to avoid flashing it during fast reconnects. */
+  private static final long SHOW_DELAY_MS = 2500;
+
+  /** How often we re-attempt the load while the overlay is visible (acts as the connectivity poll). */
+  private static final long POLL_INTERVAL_MS = 3000;
+
+  private final Activity activity;
+  private final Bridge bridge;
+  private final WebView webView;
+  private final String serverUrl;
+  private final ConnectivityManager connectivityManager;
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+  private FrameLayout overlay;
+  private boolean loaded = false;
+  private boolean overlayShowScheduled = false;
+  private boolean polling = false;
+
+  /** Path (+query) of a deep link received while offline, to be applied on the recovery load. */
+  private String pendingPath = null;
+
+  private ConnectivityManager.NetworkCallback networkCallback;
+
+  private OfflineGate(Activity activity, Bridge bridge) {
+    this.activity = activity;
+    this.bridge = bridge;
+    this.webView = bridge.getWebView();
+    this.serverUrl = bridge.getConfig().getServerUrl();
+    this.connectivityManager =
+      (ConnectivityManager) activity.getSystemService(Context.CONNECTIVITY_SERVICE);
+  }
+
+  /**
+   * Attaches an offline gate to the given activity. Safe to call unconditionally: it becomes a no-op
+   * when no remote {@code server.url} is configured.
+   */
+  public static OfflineGate attach(Activity activity, Bridge bridge) {
+    OfflineGate gate = new OfflineGate(activity, bridge);
+    gate.start();
+    return gate;
+  }
+
+  private void start() {
+    if (serverUrl == null || serverUrl.isEmpty() || webView == null) {
+      // No remote server URL (local build) — nothing to gate.
+      return;
+    }
+
+    // Capture a deep link that launched the app cold while we may be offline.
+    captureDeepLink(activity.getIntent());
+
+    // React immediately when connectivity (re)appears.
+    registerNetworkCallback();
+
+    // Detect a failed initial load of the remote site.
+    bridge.addWebViewListener(new WebViewListener() {
+      @Override
+      public void onPageLoaded(WebView webView) {
+        // The remote site loaded successfully — tear everything down.
+        markLoaded();
+      }
+
+      @Override
+      public void onReceivedError(WebView webView) {
+        // Main-frame load failed (typically offline). Show the overlay after a short grace period.
+        if (!loaded && !isOnline()) {
+          scheduleShowOverlay();
+        }
+      }
+    });
+
+    // If we already know we're offline at startup, schedule the overlay without waiting for an error.
+    if (!isOnline()) {
+      scheduleShowOverlay();
+    }
+  }
+
+  private boolean isOnline() {
+    if (connectivityManager == null) return false;
+    Network network = connectivityManager.getActiveNetwork();
+    if (network == null) return false;
+    NetworkCapabilities caps = connectivityManager.getNetworkCapabilities(network);
+    return caps != null
+      && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+      && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
+  }
+
+  private void registerNetworkCallback() {
+    if (connectivityManager == null) return;
+    NetworkRequest request = new NetworkRequest.Builder()
+      .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+      .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+      .build();
+    networkCallback = new ConnectivityManager.NetworkCallback() {
+      @Override
+      public void onAvailable(Network network) {
+        // Validated connectivity is back — retry the load right away.
+        mainHandler.post(() -> {
+          if (!loaded) reloadRemote();
+        });
+      }
+    };
+    try {
+      connectivityManager.registerNetworkCallback(request, networkCallback);
+    } catch (RuntimeException e) {
+      // Ignore: polling (below) still recovers the connection.
+      networkCallback = null;
+    }
+  }
+
+  private void scheduleShowOverlay() {
+    if (overlayShowScheduled || overlay != null || loaded) return;
+    overlayShowScheduled = true;
+    mainHandler.postDelayed(() -> {
+      overlayShowScheduled = false;
+      if (!loaded && overlay == null) {
+        showOverlay();
+        startPolling();
+      }
+    }, SHOW_DELAY_MS);
+  }
+
+  private void showOverlay() {
+    Context ctx = activity;
+
+    overlay = new FrameLayout(ctx);
+    overlay.setBackgroundColor(Color.WHITE);
+    overlay.setClickable(true); // swallow touches to the WebView underneath
+
+    LinearLayout column = new LinearLayout(ctx);
+    column.setOrientation(LinearLayout.VERTICAL);
+    column.setGravity(Gravity.CENTER);
+    int pad = dp(32);
+    column.setPadding(pad, pad, pad, pad);
+
+    TextView message = new TextView(ctx);
+    message.setText(activity.getString(R.string.offline_message));
+    message.setTextColor(Color.parseColor("#333333"));
+    message.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
+    message.setGravity(Gravity.CENTER);
+
+    ProgressBar spinner = new ProgressBar(ctx);
+    LinearLayout.LayoutParams spinnerParams = new LinearLayout.LayoutParams(
+      ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    spinnerParams.topMargin = dp(24);
+    spinnerParams.bottomMargin = dp(12);
+    spinner.setLayoutParams(spinnerParams);
+
+    TextView connecting = new TextView(ctx);
+    connecting.setText(activity.getString(R.string.offline_connecting));
+    connecting.setTextColor(Color.parseColor("#777777"));
+    connecting.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+    connecting.setGravity(Gravity.CENTER);
+
+    column.addView(message);
+    column.addView(spinner);
+    column.addView(connecting);
+
+    FrameLayout.LayoutParams columnParams = new FrameLayout.LayoutParams(
+      ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    columnParams.gravity = Gravity.CENTER;
+    overlay.addView(column, columnParams);
+
+    ViewGroup content = activity.findViewById(android.R.id.content);
+    content.addView(overlay, new FrameLayout.LayoutParams(
+      ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+    overlay.bringToFront();
+  }
+
+  private void removeOverlay() {
+    if (overlay != null) {
+      ViewGroup parent = (ViewGroup) overlay.getParent();
+      if (parent != null) parent.removeView(overlay);
+      overlay = null;
+    }
+  }
+
+  private void startPolling() {
+    if (polling) return;
+    polling = true;
+    mainHandler.postDelayed(pollRunnable, POLL_INTERVAL_MS);
+  }
+
+  private final Runnable pollRunnable = new Runnable() {
+    @Override
+    public void run() {
+      if (loaded) return;
+      reloadRemote();
+      mainHandler.postDelayed(this, POLL_INTERVAL_MS);
+    }
+  };
+
+  /** Reloads the remote site, applying any deep link captured while offline. */
+  private void reloadRemote() {
+    if (webView == null || loaded) return;
+    final String url = buildLoadUrl();
+    webView.post(() -> webView.loadUrl(url));
+  }
+
+  private String buildLoadUrl() {
+    if (pendingPath == null || pendingPath.isEmpty()) {
+      return serverUrl;
+    }
+    String base = serverUrl.endsWith("/") ? serverUrl.substring(0, serverUrl.length() - 1) : serverUrl;
+    return base + pendingPath;
+  }
+
+  private void markLoaded() {
+    if (loaded) return;
+    loaded = true;
+    pendingPath = null;
+    mainHandler.removeCallbacks(pollRunnable);
+    polling = false;
+    removeOverlay();
+    unregisterNetworkCallback();
+  }
+
+  private void unregisterNetworkCallback() {
+    if (connectivityManager != null && networkCallback != null) {
+      try {
+        connectivityManager.unregisterNetworkCallback(networkCallback);
+      } catch (RuntimeException ignored) {
+        // Already unregistered.
+      }
+      networkCallback = null;
+    }
+  }
+
+  /**
+   * Should be called from {@code MainActivity.onNewIntent}. While the gate is still active (remote
+   * site not yet loaded), it stores the deep link so it can be applied to the recovery load.
+   */
+  public void handleNewIntent(Intent intent) {
+    if (!loaded) {
+      captureDeepLink(intent);
+    }
+  }
+
+  private void captureDeepLink(Intent intent) {
+    if (intent == null) return;
+    Uri data = intent.getData();
+    if (data == null) return;
+    String path = data.getPath();
+    if (path == null) return;
+    String query = data.getQuery();
+    StringBuilder sb = new StringBuilder(path);
+    if (query != null && !query.isEmpty()) {
+      sb.append('?').append(query);
+    }
+    String fragment = data.getFragment();
+    if (fragment != null && !fragment.isEmpty()) {
+      sb.append('#').append(fragment);
+    }
+    pendingPath = sb.toString();
+  }
+
+  /** Should be called from {@code MainActivity.onDestroy}. */
+  public void destroy() {
+    mainHandler.removeCallbacks(pollRunnable);
+    unregisterNetworkCallback();
+    removeOverlay();
+  }
+
+  private int dp(int value) {
+    float density = activity.getResources().getDisplayMetrics().density;
+    return Math.round(value * density);
+  }
+}

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="offline_message">Welcome To My Garden benötigt eine Internetverbindung</string>
+    <string name="offline_connecting">Verbindung wird hergestellt…</string>
+</resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="offline_message">Welcome To My Garden necesita una conexión a Internet</string>
+    <string name="offline_connecting">Intentando conectar…</string>
+</resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="offline_message">Welcome To My Garden a besoin d\'une connexion Internet</string>
+    <string name="offline_connecting">Tentative de connexion…</string>
+</resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="offline_message">Welcome To My Garden heeft een internetverbinding nodig</string>
+    <string name="offline_connecting">Bezig met verbinden…</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
     <string name="package_name">org.welcometomygarden.app</string>
     <string name="custom_url_scheme">org.welcometomygarden.app</string>
     <string name="default_notification_channel_id">chat-notifications</string>
+    <!-- Offline gate (shown natively when the remote site can\'t load due to no internet) -->
+    <string name="offline_message">Welcome To My Garden needs an internet connection</string>
+    <string name="offline_connecting">Trying to connect…</string>
 </resources>

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		438576CD2F7AB3DA00C0B835 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 438576CC2F7AB3DA00C0B835 /* PrivacyInfo.xcprivacy */; };
 		438576CE2F7AB3DA00C0B835 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 438576CC2F7AB3DA00C0B835 /* PrivacyInfo.xcprivacy */; };
 		43B6BF8F2E798B3F00E9FA7C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		ABCDEF012E798B3F00E9FA02 /* OfflineGateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012E798B3F00E9FA01 /* OfflineGateViewController.swift */; };
+		ABCDEF012E798B3F00E9FA03 /* OfflineGateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF012E798B3F00E9FA01 /* OfflineGateViewController.swift */; };
 		43B6BF932E798B3F00E9FA7C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		43B6BF942E798B3F00E9FA7C /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
 		43B6BF952E798B3F00E9FA7C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
@@ -42,6 +44,7 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		ABCDEF012E798B3F00E9FA01 /* OfflineGateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineGateViewController.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -149,6 +152,7 @@
 				43C63E0A2E4A465100B30031 /* AppDebug.entitlements */,
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				ABCDEF012E798B3F00E9FA01 /* OfflineGateViewController.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -368,6 +372,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43B6BF8F2E798B3F00E9FA7C /* AppDelegate.swift in Sources */,
+				ABCDEF012E798B3F00E9FA02 /* OfflineGateViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +381,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				ABCDEF012E798B3F00E9FA03 /* OfflineGateViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -39,6 +39,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call
+        // Store the link so the offline gate can re-apply it once connectivity is restored.
+        OfflinePendingLink.shared.capture(url)
         return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
     }
 
@@ -46,6 +48,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the app was launched with an activity, including Universal Links.
         // Feel free to add additional processing here, but if you want the App API to support
         // tracking app url opens, make sure to keep this call
+        // Store the link so the offline gate can re-apply it once connectivity is restored.
+        if let url = userActivity.webpageURL {
+            OfflinePendingLink.shared.capture(url)
+        }
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="OfflineGateViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/ios/App/App/OfflineGateViewController.swift
+++ b/ios/App/App/OfflineGateViewController.swift
@@ -1,0 +1,240 @@
+import UIKit
+import WebKit
+import Network
+import Capacitor
+
+/// Shared store for deep links that arrive while the app is offline, so they can be re-applied once
+/// connectivity is restored and the remote site loads. Populated from `AppDelegate` (custom URL
+/// schemes and Universal Links) and consumed by `OfflineGateViewController`.
+final class OfflinePendingLink {
+    static let shared = OfflinePendingLink()
+    private init() {}
+
+    var path: String?
+
+    func capture(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return }
+        var result = components.path
+        if let query = components.query, !query.isEmpty {
+            result += "?" + query
+        }
+        if let fragment = components.fragment, !fragment.isEmpty {
+            result += "#" + fragment
+        }
+        if !result.isEmpty {
+            path = result
+        }
+    }
+}
+
+/// Native "offline gate" for the Capacitor app.
+///
+/// In production the app loads the remote website via Capacitor's `server.url`. The splash screen is
+/// configured with `launchAutoHide: false` and is only hidden once the remote site's JavaScript boots
+/// (see `src/routes/+layout.svelte`). When the device has no internet connection at startup, the
+/// remote site never loads, the JS never runs, and the splash screen stays on screen forever.
+///
+/// This controller watches connectivity (via `NWPathMonitor`) and the WebView's load progress. If the
+/// remote site can't be reached because the device is offline, it shows a native, localized overlay
+/// with a spinner, polls for connectivity, and reloads `server.url` as soon as the connection is
+/// restored. Deep links received while offline are re-applied on the recovery load.
+class OfflineGateViewController: CAPBridgeViewController {
+
+    /// Grace period before showing the overlay, to avoid flashing it during fast reconnects.
+    private let showDelay: TimeInterval = 2.5
+    /// How often we re-attempt the load while the overlay is visible (the connectivity poll).
+    private let pollInterval: TimeInterval = 3.0
+
+    private let monitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "org.welcometomygarden.app.offlinegate")
+
+    private var overlay: UIView?
+    private var loaded = false
+    private var overlayShowScheduled = false
+    private var pollTimer: Timer?
+    private var progressObservation: NSKeyValueObservation?
+
+    private var serverURL: URL? {
+        return bridge?.config.serverURL
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Only gate when a remote server URL is configured (production/staging builds).
+        guard serverURL != nil else { return }
+
+        observeLoadProgress()
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                guard let self = self, !self.loaded else { return }
+                if path.status == .satisfied {
+                    // Connectivity is available — (re)try the remote load.
+                    self.reloadRemote()
+                } else {
+                    // Offline — show the overlay after a short grace period.
+                    self.scheduleShowOverlay()
+                }
+            }
+        }
+        monitor.start(queue: monitorQueue)
+    }
+
+    // MARK: - Load progress
+
+    private func observeLoadProgress() {
+        guard let webView = webView else { return }
+        progressObservation = webView.observe(\.estimatedProgress, options: [.new]) { [weak self] webView, _ in
+            guard let self = self, !self.loaded else { return }
+            // A committed navigation that reaches full progress on the configured host means the
+            // remote site loaded successfully.
+            if webView.estimatedProgress >= 1.0,
+               let host = webView.url?.host,
+               host == self.serverURL?.host {
+                DispatchQueue.main.async { self.markLoaded() }
+            }
+        }
+    }
+
+    // MARK: - Overlay
+
+    private func scheduleShowOverlay() {
+        if overlayShowScheduled || overlay != nil || loaded { return }
+        overlayShowScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + showDelay) { [weak self] in
+            guard let self = self else { return }
+            self.overlayShowScheduled = false
+            if !self.loaded && self.overlay == nil {
+                self.showOverlay()
+                self.startPolling()
+            }
+        }
+    }
+
+    private func showOverlay() {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = .systemBackground
+
+        let message = UILabel()
+        message.text = OfflineGateViewController.localized(.message)
+        message.numberOfLines = 0
+        message.textAlignment = .center
+        message.font = .systemFont(ofSize: 18, weight: .semibold)
+        message.textColor = .label
+
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.startAnimating()
+
+        let connecting = UILabel()
+        connecting.text = OfflineGateViewController.localized(.connecting)
+        connecting.textAlignment = .center
+        connecting.font = .systemFont(ofSize: 14)
+        connecting.textColor = .secondaryLabel
+
+        let stack = UIStackView(arrangedSubviews: [message, spinner, connecting])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+
+        view.addSubview(container)
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: view.topAnchor),
+            container.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            container.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 32),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -32)
+        ])
+
+        view.bringSubviewToFront(container)
+        overlay = container
+    }
+
+    private func removeOverlay() {
+        overlay?.removeFromSuperview()
+        overlay = nil
+    }
+
+    // MARK: - Polling & reload
+
+    private func startPolling() {
+        guard pollTimer == nil else { return }
+        pollTimer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
+            guard let self = self, !self.loaded else { return }
+            self.reloadRemote()
+        }
+    }
+
+    /// Reloads the remote site, applying any deep link captured while offline.
+    private func reloadRemote() {
+        guard !loaded, let webView = webView, var url = serverURL else { return }
+        if let path = OfflinePendingLink.shared.path, !path.isEmpty,
+           let combined = URL(string: path, relativeTo: url) {
+            url = combined
+        }
+        webView.load(URLRequest(url: url))
+    }
+
+    private func markLoaded() {
+        if loaded { return }
+        loaded = true
+        OfflinePendingLink.shared.path = nil
+        pollTimer?.invalidate()
+        pollTimer = nil
+        monitor.cancel()
+        progressObservation?.invalidate()
+        progressObservation = nil
+        removeOverlay()
+    }
+
+    deinit {
+        pollTimer?.invalidate()
+        monitor.cancel()
+        progressObservation?.invalidate()
+    }
+
+    // MARK: - Localization
+
+    private enum StringKey {
+        case message
+        case connecting
+    }
+
+    /// The native UI is shown before any web/JS i18n is available, so the supported-language strings
+    /// are embedded here and selected from the device language (falling back to English).
+    private static func localized(_ key: StringKey) -> String {
+        let messages: [String: String] = [
+            "en": "Welcome To My Garden needs an internet connection",
+            "nl": "Welcome To My Garden heeft een internetverbinding nodig",
+            "fr": "Welcome To My Garden a besoin d’une connexion Internet",
+            "de": "Welcome To My Garden benötigt eine Internetverbindung",
+            "es": "Welcome To My Garden necesita una conexión a Internet"
+        ]
+        let connecting: [String: String] = [
+            "en": "Trying to connect…",
+            "nl": "Bezig met verbinden…",
+            "fr": "Tentative de connexion…",
+            "de": "Verbindung wird hergestellt…",
+            "es": "Intentando conectar…"
+        ]
+        let table = key == .message ? messages : connecting
+        let lang = deviceLanguage(supported: Array(table.keys))
+        return table[lang] ?? table["en"] ?? ""
+    }
+
+    private static func deviceLanguage(supported: [String]) -> String {
+        for preferred in Locale.preferredLanguages {
+            let code = String(preferred.prefix(2)).lowercased()
+            if supported.contains(code) {
+                return code
+            }
+        }
+        return "en"
+    }
+}


### PR DESCRIPTION
## Problem

In production the Capacitor app loads the remote website via `server.url`. The splash screen is configured with `launchAutoHide: false` and is only hidden once the remote site's JS boots (`SplashScreen.hide()` in `src/routes/+layout.svelte`).

When the device has **no internet connection at startup**, the remote site never loads → the JS never runs → the splash screen stays on screen forever.

## Why this can't be solved in the web layer / with `@capacitor/network`

Any web-layer fix lives in code that only executes once the remote site loads. Connectivity plugins like `@capacitor/network` run in that same JS context that never boots when offline. The detection, native UI, and reconnect-and-load logic therefore **must** live in native code, around the WebView load. No well-maintained third-party plugin gates a remote `server.url` load behind connectivity with a native offline screen, so this is implemented natively in the existing `android/` and `ios/` projects (consistent with how `MainActivity`/`AppDelegate` are already customized). The hard requirement of using a remote `server.url` (no local Capacitor server) is preserved.

## Behavior

On both Android and iOS, a native "offline gate":

1. Watches the initial remote load and device connectivity.
2. If offline, after a **short grace period (~2.5s)** — to avoid flashing during fast reconnects — shows a **native, localized** overlay: _"Welcome To My Garden needs an internet connection"_, a **spinner**, and a _"Trying to connect…"_ label, in the device language (**en / nl / fr / de / es**, fallback en).
3. **Polls / listens** for connectivity (system network callbacks + a periodic reload) and reloads `server.url` as soon as the connection is restored. On success the overlay is removed and everything is torn down.
4. **Stores deep links** (`appUrlOpen` / Universal Links / custom scheme) received while offline and re-applies them to the recovery load (loads `server.url` + the captured path), so the launch intent isn't lost.

The gate disables itself when no remote `server.url` is configured (local/dev builds).

## Changes

**Android**
- `OfflineGate.java` — connectivity + WebView-load watcher, native overlay, polling, deep-link capture/replay. Attached from `MainActivity` (`onCreate`/`onNewIntent`/`onDestroy`).
- Localized `offline_message` / `offline_connecting` strings in `values/` (en) + `values-nl/fr/de/es`.

**iOS**
- `OfflineGateViewController.swift` — `CAPBridgeViewController` subclass using `NWPathMonitor` + KVO on load progress, native overlay (embedded localized strings), polling, deep-link replay.
- `Main.storyboard` points the bridge VC at the subclass; deep links captured in `AppDelegate`; file registered in both targets (App / App Staging) in `project.pbxproj`.

## ⚠️ Testing notes

These are native cross-platform changes and **could not be compiled/tested in the web environment** (no `node_modules`, no Android/iOS toolchain). Please verify on-device:

- [ ] Android: launch with airplane mode on → splash gives way to the localized offline overlay after a couple of seconds; toggling connectivity back loads the site.
- [ ] iOS: same flow (real device — simulator network behaves differently).
- [ ] Confirm the Capacitor API assumptions hold for v8: Android `bridge.getConfig().getServerUrl()`, `bridge.addWebViewListener(...)`, `WebViewListener#onPageLoaded/onReceivedError`; iOS `bridge?.config.serverURL`, `webView`.
- [ ] Cold-start deep link while offline lands on the right page after reconnect.
- [ ] Normal online launch is unaffected (no overlay flash, deep links still handled by the existing `appUrlOpen` listener).

Out of scope (per request): offline alerts after the site has already loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dz2FRGy1Riw811mT3be2UN)_