### PR TITLE
Route file display tweaks prototype: endpoint styles, km markers &amp; overlaps

### DIFF
--- a/.github/workflows/firebase-hosting-pr-preview.yml
+++ b/.github/workflows/firebase-hosting-pr-preview.yml
@@ -12,7 +12,7 @@ on:
       - firestore*
       # Updated docs shouldn't trigger deploys
       - docs/**
-      - '*.md'
+      - "*.md"
       # We don't block a deploy on failed tests yet
       - tests/**
       - ci/**
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build_and_deploy:
-    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -51,16 +51,22 @@ jobs:
       PUBLIC_SUPABASE_API_URL: ${{vars.SUPABASE_API_URL}}
       PUBLIC_SENTRY_DSN: ${{vars.SENTRY_DSN}}
       PUBLIC_WTMG_HOST: ${{vars.WTMG_HOST}}
-      IS_PREVIEW: 'true'
+      IS_PREVIEW: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/prepare-source
       - name: Build project
         run: yarn run build:staging
+      - name: Pin Node for deploy
+        # workaround for https://github.com/FirebaseExtended/action-hosting-deploy/issues/460 and
+        # and https://github.com/firebase/firebase-tools/issues/10716#issuecomment-4800040219
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.18.0
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_DEV }}'
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_WTMG_DEV }}"
           projectId: wtmg-dev
           target: beta
           # 30d is the maximum https://firebase.google.com/docs/hosting/manage-hosting-resources#preview-channel-expiration

--- a/src/lib/components/LayersAndTools/TrailsTool.svelte
+++ b/src/lib/components/LayersAndTools/TrailsTool.svelte
@@ -4,6 +4,8 @@
   import { LabeledCheckbox, MultiActionLabel, Button, Icon } from '$lib/components/UI';
   import { cyclistIcon, hikerIcon, routesIcon } from '$lib/images/icons';
   import { fileDataLayers } from '$lib/stores/file';
+  import { routeTweaks } from '$lib/stores/routeTweaks';
+  import { colorForRoute } from '$lib/util/map/routeStyle';
   import { cleanName } from '$lib/util/slugify';
   import { onDestroy } from 'svelte';
   import { deleteTrail, toggleTrailVisibility } from '$lib/api/trail';
@@ -50,15 +52,26 @@
 </div>
 
 <div class="data-layers" class:in-modal={inModal}>
-  {#each localFileDataLayers as layer}
-    <MultiActionLabel
-      icon={routesIcon}
-      name={layer.id}
-      label={cleanName(layer.originalFileName)}
-      checked={layer.visible}
-      onchange={() => toggleTrailVisibility(layer.id)}
-      onsecondary={() => deleteTrail(layer.id)}
-    />
+  {#each localFileDataLayers as layer, index}
+    <div class="trail-row">
+      <div class="trail-label">
+        <MultiActionLabel
+          icon={routesIcon}
+          name={layer.id}
+          label={cleanName(layer.originalFileName)}
+          checked={layer.visible}
+          onchange={() => toggleTrailVisibility(layer.id)}
+          onsecondary={() => deleteTrail(layer.id)}
+        />
+      </div>
+      <!-- Colour indicator matching the route's colour on the map -->
+      <span
+        class="trail-color"
+        class:dimmed={!layer.visible}
+        style:background={colorForRoute(index, $routeTweaks.useMultipleColors)}
+        title="Route colour on the map"
+      ></span>
+    </div>
   {/each}
 </div>
 
@@ -74,6 +87,33 @@
 </div>
 
 <style>
+  .trail-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+    width: 100%;
+  }
+
+  .trail-label {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Vertical colour bar matching the route's colour on the map. */
+  .trail-color {
+    flex-shrink: 0;
+    width: 0.4rem;
+    align-self: stretch;
+    min-height: 2rem;
+    border-radius: 0.2rem;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+  }
+
+  .trail-color.dimmed {
+    opacity: 0.3;
+  }
+
   .button-text-container {
     display: inline-flex;
     align-items: center;

--- a/src/lib/components/LayersAndTools/TrailsTool.svelte
+++ b/src/lib/components/LayersAndTools/TrailsTool.svelte
@@ -53,25 +53,24 @@
 
 <div class="data-layers" class:in-modal={inModal}>
   {#each localFileDataLayers as layer, index}
-    <div class="trail-row">
-      <div class="trail-label">
-        <MultiActionLabel
-          icon={routesIcon}
-          name={layer.id}
-          label={cleanName(layer.originalFileName)}
-          checked={layer.visible}
-          onchange={() => toggleTrailVisibility(layer.id)}
-          onsecondary={() => deleteTrail(layer.id)}
-        />
-      </div>
-      <!-- Colour indicator matching the route's colour on the map -->
-      <span
-        class="trail-color"
-        class:dimmed={!layer.visible}
-        style:background={colorForRoute(index, $routeTweaks.useMultipleColors)}
-        title="Route colour on the map"
-      ></span>
-    </div>
+    <MultiActionLabel
+      icon={routesIcon}
+      name={layer.id}
+      label={cleanName(layer.originalFileName)}
+      checked={layer.visible}
+      onchange={() => toggleTrailVisibility(layer.id)}
+      onsecondary={() => deleteTrail(layer.id)}
+    >
+      {#snippet leading()}
+        <!-- Colour indicator matching the route's colour on the map -->
+        <span
+          class="trail-color"
+          class:dimmed={!layer.visible}
+          style:background={colorForRoute(index, $routeTweaks.useMultipleColors)}
+          title="Route colour on the map"
+        ></span>
+      {/snippet}
+    </MultiActionLabel>
   {/each}
 </div>
 
@@ -87,26 +86,15 @@
 </div>
 
 <style>
-  .trail-row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.6rem;
-    width: 100%;
-  }
-
-  .trail-label {
-    flex: 1;
-    min-width: 0;
-  }
-
-  /* Vertical colour bar matching the route's colour on the map. */
+  /* Vertical colour bar matching the route's colour on the map, shown between the
+     checkbox and the route name. Kept shorter than the row so there's a gap between
+     consecutive bars. */
   .trail-color {
     flex-shrink: 0;
-    width: 0.4rem;
-    align-self: stretch;
-    min-height: 2rem;
-    border-radius: 0.2rem;
+    width: 0.5rem;
+    height: 1.4rem;
+    margin-right: 0.6rem;
+    border-radius: 0.25rem;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
   }
 

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -58,10 +58,30 @@
   const kmMarkersFor = (geoJson: FileDataLayer['geoJson']) =>
     effInterval != null ? computeKmMarkers(geoJson, effInterval) : EMPTY_KM;
 
+  // Effective km marker opacity: the zoom-driven fade, unless fading is disabled — in
+  // which case markers simply snap between fully visible and hidden.
+  const kmOpacity = () => (get(routeTweaks).fadeKmMarkers ? effOpacity : effOpacity > 0 ? 1 : 0);
+
+  // Route line opacity: reduced when the "transparent routes" tweak is on, so the
+  // underlying road stays visible through the line.
+  const ROUTE_OPACITY = 0.8;
+  const ROUTE_OPACITY_TRANSPARENT = 0.45;
+  const OVERLAP_OPACITY = 0.9;
+  const OVERLAP_OPACITY_TRANSPARENT = 0.5;
+  const lineOpacity = () =>
+    get(routeTweaks).transparentRoutes ? ROUTE_OPACITY_TRANSPARENT : ROUTE_OPACITY;
+  const overlapOpacity = () =>
+    get(routeTweaks).transparentRoutes ? OVERLAP_OPACITY_TRANSPARENT : OVERLAP_OPACITY;
+
   // Layer/source id helpers (the base `id` stays the line layer/source, for backwards compat).
   const kmSourceId = (id: string) => `${id}__km`;
   const kmCircleId = (id: string) => `${id}__km-circle`;
   const kmLabelId = (id: string) => `${id}__km-label`;
+  const nameLabelId = (id: string) => `${id}__name`;
+
+  /** The label shown along a route: the file name minus its extension. */
+  const routeNameFor = (layer: FileDataLayer) =>
+    (layer.originalFileName ?? '').replace(/\.[^./\\]+$/, '');
 
   // Track rendered trail layers + the global set of endpoint DOM markers.
   const rendered = new Set<string>();
@@ -72,8 +92,13 @@
   // the km circle layer paint below) instead of the icon badge size.
   const KM_MARKER_DIAMETER = 18; // px, must track 'circle-radius' on the km circle layer
 
+  // 'flags' and 'dots' both draw plain circular badges sized to the km markers.
   const baseMarkerSizeFor = (mode: EndpointMode) =>
-    mode === 'flags' ? KM_MARKER_DIAMETER : BASE_MARKER_SIZE;
+    mode === 'flags' || mode === 'dots' ? KM_MARKER_DIAMETER : BASE_MARKER_SIZE;
+
+  // Solid badge colours shared by the 'flags' (start) and 'dots' (start/end/merged) modes.
+  const BADGE_GREEN = 'rgba(27, 120, 55, 0.92)';
+  const BADGE_RED = 'rgba(216, 67, 33, 0.92)';
 
   const fitToTrail = (geoJson: FileDataLayer['geoJson']) => {
     try {
@@ -143,12 +168,22 @@
     if (mode === 'flags') {
       if (type === 'start') {
         // Plain, mostly-opaque green circle (no icon).
-        el.style.background = 'rgba(27, 120, 55, 0.92)';
+        el.style.background = BADGE_GREEN;
       } else {
         // End & merged (pause) => checkerboard finish badge.
         el.style.background = '#fff';
         el.innerHTML = CHECKERBOARD_SVG;
       }
+      return el;
+    }
+
+    if (mode === 'dots') {
+      // Green circle (start), red circle (end) and a vertically split
+      // half-green/half-red circle for merged start+end points.
+      if (type === 'start') el.style.background = BADGE_GREEN;
+      else if (type === 'end') el.style.background = BADGE_RED;
+      else
+        el.style.background = `linear-gradient(90deg, ${BADGE_GREEN} 0 50%, ${BADGE_RED} 50% 100%)`;
       return el;
     }
 
@@ -220,6 +255,9 @@
     const kmVisible = lineVisible && tweaks.showKmMarkers;
     setLayerVisibility(kmCircleId(layer.id), kmVisible);
     setLayerVisibility(kmLabelId(layer.id), kmVisible);
+
+    const nameVisible = lineVisible && tweaks.showRouteNames;
+    setLayerVisibility(nameLabelId(layer.id), nameVisible);
   };
 
   const renderTrail = (layer: FileDataLayer, color: string, tweaks: RouteTweaks) => {
@@ -239,10 +277,11 @@
         type: 'line',
         source: id,
         layout: { 'line-join': 'round', 'line-cap': 'round' },
-        paint: { 'line-width': 7, 'line-color': color, 'line-opacity': 0.8 }
+        paint: { 'line-width': 7, 'line-color': color, 'line-opacity': lineOpacity() }
       });
     } else {
       map.setPaintProperty(id, 'line-color', color);
+      map.setPaintProperty(id, 'line-opacity', lineOpacity());
     }
 
     // Zoom to the trail only when we just added it locally.
@@ -264,16 +303,16 @@
         paint: {
           'circle-color': 'rgba(255, 255, 255, 0.75)',
           'circle-radius': 9,
-          'circle-opacity': effOpacity,
+          'circle-opacity': kmOpacity(),
           'circle-stroke-width': 1.5,
           'circle-stroke-color': color,
-          'circle-stroke-opacity': effOpacity
+          'circle-stroke-opacity': kmOpacity()
         }
       });
     } else {
       map.setPaintProperty(kmCircleId(id), 'circle-stroke-color', color);
-      map.setPaintProperty(kmCircleId(id), 'circle-opacity', effOpacity);
-      map.setPaintProperty(kmCircleId(id), 'circle-stroke-opacity', effOpacity);
+      map.setPaintProperty(kmCircleId(id), 'circle-opacity', kmOpacity());
+      map.setPaintProperty(kmCircleId(id), 'circle-stroke-opacity', kmOpacity());
     }
 
     if (!map.getLayer(kmLabelId(id))) {
@@ -287,11 +326,37 @@
           'text-allow-overlap': true,
           'text-ignore-placement': true
         },
-        paint: { 'text-color': color, 'text-opacity': effOpacity }
+        paint: { 'text-color': color, 'text-opacity': kmOpacity() }
       });
     } else {
       map.setPaintProperty(kmLabelId(id), 'text-color', color);
-      map.setPaintProperty(kmLabelId(id), 'text-opacity', effOpacity);
+      map.setPaintProperty(kmLabelId(id), 'text-opacity', kmOpacity());
+    }
+
+    // --- Route name label (repeated along the line) ---
+    const routeName = routeNameFor(layer);
+    if (!map.getLayer(nameLabelId(id))) {
+      map.addLayer({
+        id: nameLabelId(id),
+        type: 'symbol',
+        source: id,
+        layout: {
+          'symbol-placement': 'line',
+          'symbol-spacing': 250,
+          'text-field': routeName,
+          'text-size': 13,
+          'text-max-angle': 40,
+          'text-keep-upright': true
+        },
+        paint: {
+          'text-color': color,
+          'text-halo-color': 'rgba(255, 255, 255, 0.9)',
+          'text-halo-width': 1.5
+        }
+      });
+    } else {
+      map.setLayoutProperty(nameLabelId(id), 'text-field', routeName);
+      map.setPaintProperty(nameLabelId(id), 'text-color', color);
     }
 
     // Start/end markers are managed globally (see rebuildEndpointMarkers).
@@ -303,7 +368,7 @@
   };
 
   const removeTrail = (id: string) => {
-    [kmLabelId(id), kmCircleId(id), id].forEach((layerId) => {
+    [nameLabelId(id), kmLabelId(id), kmCircleId(id), id].forEach((layerId) => {
       if (map.getLayer(layerId)) map.removeLayer(layerId);
     });
     if (map.getSource(kmSourceId(id))) map.removeSource(kmSourceId(id));
@@ -319,6 +384,7 @@
   /** Brings a trail's line and km marker layers above everything else. */
   const raiseTrail = (id: string) => {
     moveToTop(id);
+    moveToTop(nameLabelId(id));
     moveToTop(kmCircleId(id));
     moveToTop(kmLabelId(id));
   };
@@ -351,6 +417,15 @@
       return;
     }
 
+    // Keep the overlap-line opacity in sync with the "transparent routes" tweak. Done
+    // before the signature short-circuit below, which only tracks route ids/colours.
+    if (map.getLayer(OVERLAP_LAYER_A)) {
+      map.setPaintProperty(OVERLAP_LAYER_A, 'line-opacity', overlapOpacity());
+    }
+    if (map.getLayer(OVERLAP_LAYER_B)) {
+      map.setPaintProperty(OVERLAP_LAYER_B, 'line-opacity', overlapOpacity());
+    }
+
     const tweaks = get(routeTweaks);
     const routes = get(fileDataLayers)
       .map((layer, index) => ({
@@ -380,7 +455,11 @@
         type: 'line',
         source: OVERLAP_SOURCE,
         layout: { 'line-join': 'round', 'line-cap': 'round' },
-        paint: { 'line-width': 7, 'line-color': ['get', 'colorA'], 'line-opacity': 0.9 }
+        paint: {
+          'line-width': 7,
+          'line-color': ['get', 'colorA'],
+          'line-opacity': overlapOpacity()
+        }
       });
     }
     if (!map.getLayer(OVERLAP_LAYER_B)) {
@@ -392,7 +471,7 @@
         paint: {
           'line-width': 7,
           'line-color': ['get', 'colorB'],
-          'line-opacity': 0.9,
+          'line-opacity': overlapOpacity(),
           'line-dasharray': [2, 2]
         }
       });
@@ -420,6 +499,7 @@
   const stackKmOnTop = () => {
     moveToTop(OVERLAP_LAYER_A);
     moveToTop(OVERLAP_LAYER_B);
+    currentTrailIds().forEach((id) => moveToTop(nameLabelId(id)));
     currentTrailIds().forEach((id) => moveToTop(kmCircleId(id)));
     currentTrailIds().forEach((id) => moveToTop(kmLabelId(id)));
   };
@@ -524,11 +604,11 @@
         }
       }
       if (map.getLayer(kmCircleId(id))) {
-        map.setPaintProperty(kmCircleId(id), 'circle-opacity', effOpacity);
-        map.setPaintProperty(kmCircleId(id), 'circle-stroke-opacity', effOpacity);
+        map.setPaintProperty(kmCircleId(id), 'circle-opacity', kmOpacity());
+        map.setPaintProperty(kmCircleId(id), 'circle-stroke-opacity', kmOpacity());
       }
       if (map.getLayer(kmLabelId(id))) {
-        map.setPaintProperty(kmLabelId(id), 'text-opacity', effOpacity);
+        map.setPaintProperty(kmLabelId(id), 'text-opacity', kmOpacity());
       }
     });
 

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -3,19 +3,55 @@
   import type { GeoJSONSource, Marker } from 'mapbox-gl';
   import mapboxgl from 'mapbox-gl';
   import { fileDataLayers } from '$lib/stores/file';
-  import { routeTweaks, type RouteTweaks } from '$lib/stores/routeTweaks';
+  import {
+    routeTweaks,
+    type RouteTweaks,
+    currentMapZoom,
+    effectiveKm
+  } from '$lib/stores/routeTweaks';
   import { getContext, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import { bbox } from '@turf/bbox';
   import key from './mapbox-context.js';
   import { ZOOM_LEVELS } from '$lib/constants';
   import type { FileDataLayer } from '$lib/types/DataLayer';
-  import { colorForRoute, computeKmMarkers, computeStartEnd } from '$lib/util/map/routeStyle';
+  import type { FeatureCollection, Point } from 'geojson';
+  import {
+    colorForRoute,
+    computeKmMarkers,
+    computeStartEnd,
+    evaluateZoomInterval,
+    parseZoomIntervalConfig
+  } from '$lib/util/map/routeStyle';
   import * as Sentry from '@sentry/sveltekit';
   import logger from '$lib/util/logger';
 
   const { getMap } = getContext<ContextType>(key);
   const map = getMap();
+
+  const EMPTY_KM: FeatureCollection<Point, { label: string }> = {
+    type: 'FeatureCollection',
+    features: []
+  };
+
+  // Effective km marker interval + opacity for the current zoom level (driven by the
+  // zoom→interval config in the tweaks store). `effInterval === null` => no markers.
+  let effInterval: number | null = null;
+  let effOpacity = 0;
+
+  /** Recomputes the effective interval/opacity from the live zoom + config. */
+  const refreshEffective = () => {
+    const zoom = map.getZoom();
+    currentMapZoom.set(zoom);
+    const rules = parseZoomIntervalConfig(get(routeTweaks).zoomIntervalConfig);
+    const result = evaluateZoomInterval(rules, zoom);
+    effInterval = result ? result.interval : null;
+    effOpacity = result ? result.opacity : 0;
+    effectiveKm.set(result);
+  };
+
+  const kmMarkersFor = (geoJson: FileDataLayer['geoJson']) =>
+    effInterval != null ? computeKmMarkers(geoJson, effInterval) : EMPTY_KM;
 
   // Layer/source id helpers (the base `id` stays the line layer/source, for backwards compat).
   const kmSourceId = (id: string) => `${id}__km`;
@@ -54,19 +90,18 @@
     const el = document.createElement('div');
     el.style.cssText =
       'width:24px;height:24px;border-radius:50%;display:flex;align-items:center;' +
-      'justify-content:center;border:2px solid #fff;box-sizing:border-box;' +
+      'justify-content:center;line-height:0;border:2px solid #fff;box-sizing:border-box;' +
       'box-shadow:0 1px 4px rgba(0,0,0,0.4);';
-    el.style.background = type === 'start' ? '#1b7837' : '#c1121f';
+    // Slightly transparent backgrounds; the end marker is a red-orange.
+    el.style.background = type === 'start' ? 'rgba(27, 120, 55, 0.82)' : 'rgba(216, 67, 33, 0.82)';
     el.innerHTML =
       type === 'start'
-        ? // Flag icon
-          '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#fff" ' +
-          'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
-          '<path d="M4 22V4"/><path d="M4 4h13l-2 4 2 4H4"/></svg>'
-        : // Checkered (finish) icon
-          '<svg width="13" height="13" viewBox="0 0 16 16">' +
-          '<rect x="0" y="0" width="8" height="8" fill="#fff"/>' +
-          '<rect x="8" y="8" width="8" height="8" fill="#fff"/></svg>';
+        ? // Filled play (triangle) icon
+          '<svg width="12" height="12" viewBox="0 0 24 24" fill="#fff" ' +
+          'style="display:block"><path d="M8 6v12l11-6z"/></svg>'
+        : // Filled stop (square) icon
+          '<svg width="11" height="11" viewBox="0 0 24 24" fill="#fff" ' +
+          'style="display:block"><rect x="5" y="5" width="14" height="14" rx="1.5"/></svg>';
     return el;
   };
 
@@ -146,7 +181,7 @@
     if (isNew && layer.animate) fitToTrail(geoJson);
 
     // --- Kilometre markers ---
-    const kmData = computeKmMarkers(geoJson, tweaks.kmInterval);
+    const kmData = kmMarkersFor(geoJson);
     if (!map.getSource(kmSourceId(id))) {
       map.addSource(kmSourceId(id), { type: 'geojson', data: kmData });
     } else {
@@ -161,12 +196,16 @@
         paint: {
           'circle-color': 'rgba(255, 255, 255, 0.75)',
           'circle-radius': 9,
+          'circle-opacity': effOpacity,
           'circle-stroke-width': 1.5,
-          'circle-stroke-color': color
+          'circle-stroke-color': color,
+          'circle-stroke-opacity': effOpacity
         }
       });
     } else {
       map.setPaintProperty(kmCircleId(id), 'circle-stroke-color', color);
+      map.setPaintProperty(kmCircleId(id), 'circle-opacity', effOpacity);
+      map.setPaintProperty(kmCircleId(id), 'circle-stroke-opacity', effOpacity);
     }
 
     if (!map.getLayer(kmLabelId(id))) {
@@ -180,10 +219,11 @@
           'text-allow-overlap': true,
           'text-ignore-placement': true
         },
-        paint: { 'text-color': color }
+        paint: { 'text-color': color, 'text-opacity': effOpacity }
       });
     } else {
       map.setPaintProperty(kmLabelId(id), 'text-color', color);
+      map.setPaintProperty(kmLabelId(id), 'text-opacity', effOpacity);
     }
 
     // --- Start/end markers ---
@@ -212,6 +252,7 @@
 
   /** Full reconcile of the map against the current trails + tweaks state. */
   const sync = () => {
+    refreshEffective();
     const layers = get(fileDataLayers);
     const tweaks = get(routeTweaks);
 
@@ -228,12 +269,44 @@
     });
   };
 
+  /**
+   * On zoom: re-evaluate the effective interval/opacity and update the km layers.
+   * The marker data is only recomputed when the interval actually changes; the
+   * (cheap) opacity fade is applied on every zoom frame.
+   */
+  const onZoom = () => {
+    const prevInterval = effInterval;
+    refreshEffective();
+    const intervalChanged = prevInterval !== effInterval;
+
+    rendered.forEach((id) => {
+      if (intervalChanged) {
+        const layer = get(fileDataLayers).find((l) => l.id === id);
+        if (layer) {
+          (map.getSource(kmSourceId(id)) as GeoJSONSource | undefined)?.setData(
+            kmMarkersFor(layer.geoJson)
+          );
+        }
+      }
+      if (map.getLayer(kmCircleId(id))) {
+        map.setPaintProperty(kmCircleId(id), 'circle-opacity', effOpacity);
+        map.setPaintProperty(kmCircleId(id), 'circle-stroke-opacity', effOpacity);
+      }
+      if (map.getLayer(kmLabelId(id))) {
+        map.setPaintProperty(kmLabelId(id), 'text-opacity', effOpacity);
+      }
+    });
+  };
+
+  map.on('zoom', onZoom);
+
   const unsubscribeLayers = fileDataLayers.subscribe(sync);
   const unsubscribeTweaks = routeTweaks.subscribe(sync);
 
   onDestroy(() => {
     unsubscribeLayers();
     unsubscribeTweaks();
+    map.off('zoom', onZoom);
     // Guard against the map having been torn down already (e.g. on navigation away).
     try {
       [...rendered].forEach(removeTrail);

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -87,8 +87,28 @@
     }
   };
 
-  const createEndpointElement = (type: 'start' | 'end') => {
-    const svgBase = type === 'start' ? 12 : 11;
+  // Per-type marker config: icon svg, base svg size (px) and badge background.
+  // The start (play) icon is a bit larger so it reads as balanced next to the square.
+  const ENDPOINT_CONFIG = {
+    start: {
+      svgBase: 14,
+      background: 'rgba(27, 120, 55, 0.82)', // green
+      icon: '<path d="M8 6v12l11-6z"/>' // filled play (triangle)
+    },
+    end: {
+      svgBase: 11,
+      background: 'rgba(216, 67, 33, 0.82)', // red-orange
+      icon: '<rect x="5" y="5" width="14" height="14" rx="1.5"/>' // filled stop (square)
+    },
+    pause: {
+      svgBase: 12,
+      background: 'rgba(30, 58, 138, 0.82)', // dark blue
+      icon: '<rect x="6.5" y="5" width="3.5" height="14" rx="1"/><rect x="14" y="5" width="3.5" height="14" rx="1"/>' // pause (two bars)
+    }
+  } as const;
+
+  const createEndpointElement = (type: RouteEndpoint['type']) => {
+    const { svgBase, background, icon } = ENDPOINT_CONFIG[type];
     const el = document.createElement('div');
     // `display:flex` lives in the global .trail-endpoint rule below, because mapbox
     // clears the inline `display` property it sets on marker elements.
@@ -98,16 +118,10 @@
       `width:${BASE_MARKER_SIZE}px;height:${BASE_MARKER_SIZE}px;border-radius:50%;` +
       'align-items:center;justify-content:center;line-height:0;' +
       'border:2px solid #fff;box-sizing:border-box;box-shadow:0 1px 4px rgba(0,0,0,0.4);';
-    // Slightly transparent backgrounds; the end marker is a red-orange.
-    el.style.background = type === 'start' ? 'rgba(27, 120, 55, 0.82)' : 'rgba(216, 67, 33, 0.82)';
+    el.style.background = background;
     el.innerHTML =
-      type === 'start'
-        ? // Filled play (triangle) icon
-          `<svg width="${svgBase}" height="${svgBase}" viewBox="0 0 24 24" fill="#fff" ` +
-          'style="display:block"><path d="M8 6v12l11-6z"/></svg>'
-        : // Filled stop (square) icon
-          `<svg width="${svgBase}" height="${svgBase}" viewBox="0 0 24 24" fill="#fff" ` +
-          'style="display:block"><rect x="5" y="5" width="14" height="14" rx="1.5"/></svg>';
+      `<svg width="${svgBase}" height="${svgBase}" viewBox="0 0 24 24" fill="#fff" ` +
+      `style="display:block">${icon}</svg>`;
     return el;
   };
 

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -88,8 +88,9 @@
 
   const createEndpointElement = (type: 'start' | 'end') => {
     const el = document.createElement('div');
+    el.classList.add('trail-endpoint');
     el.style.cssText =
-      'width:24px;height:24px;border-radius:50%;display:flex;align-items:center;' +
+      'width:24px;height:24px;border-radius:50%;align-items:center;' +
       'justify-content:center;line-height:0;border:2px solid #fff;box-sizing:border-box;' +
       'box-shadow:0 1px 4px rgba(0,0,0,0.4);';
     // Slightly transparent backgrounds; the end marker is a red-orange.
@@ -315,3 +316,10 @@
     }
   });
 </script>
+
+<style>
+  /* The inline css classes get overwritten/cleared by mapbox I think */
+  :global(.mapboxgl-marker.trail-endpoint) {
+    display: flex;
+  }
+</style>

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -67,7 +67,13 @@
   const rendered = new Set<string>();
   let endpointMarkers: Marker[] = [];
 
-  const BASE_MARKER_SIZE = 24; // px, badge diameter at full size
+  const BASE_MARKER_SIZE = 24; // px, badge diameter at full size ('icons' mode)
+  // In 'flags' mode, match the km markers' diameter (2 * their circle-radius, see
+  // the km circle layer paint below) instead of the icon badge size.
+  const KM_MARKER_DIAMETER = 18; // px, must track 'circle-radius' on the km circle layer
+
+  const baseMarkerSizeFor = (mode: EndpointMode) =>
+    mode === 'flags' ? KM_MARKER_DIAMETER : BASE_MARKER_SIZE;
 
   const fitToTrail = (geoJson: FileDataLayer['geoJson']) => {
     try {
@@ -124,12 +130,13 @@
     '</svg>';
 
   const createEndpointElement = (type: RouteEndpoint['type'], mode: EndpointMode) => {
+    const baseSize = baseMarkerSizeFor(mode);
     const el = document.createElement('div');
     // `display:flex` lives in the global .trail-endpoint rule below, because mapbox
     // clears the inline `display` property it sets on marker elements.
     el.classList.add('trail-endpoint');
     el.style.cssText =
-      `width:${BASE_MARKER_SIZE}px;height:${BASE_MARKER_SIZE}px;border-radius:50%;` +
+      `width:${baseSize}px;height:${baseSize}px;border-radius:50%;` +
       'align-items:center;justify-content:center;line-height:0;overflow:hidden;' +
       'border:2px solid #fff;box-sizing:border-box;box-shadow:0 1px 4px rgba(0,0,0,0.4);';
 
@@ -158,7 +165,7 @@
   /** Applies the current zoom-based scale & opacity to all endpoint markers. */
   const applyEndpointStyle = () => {
     const { scale, opacity } = computeEndpointStyle(map.getZoom());
-    const size = BASE_MARKER_SIZE * scale;
+    const size = baseMarkerSizeFor(get(routeTweaks).endpointMode) * scale;
     for (const marker of endpointMarkers) {
       const el = marker.getElement();
       el.style.width = `${size}px`;

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -272,6 +272,73 @@
     rendered.delete(id);
   };
 
+  const moveToTop = (layerId: string) => {
+    if (map.getLayer(layerId)) map.moveLayer(layerId);
+  };
+
+  /** Brings a trail's line and km marker layers above everything else. */
+  const raiseTrail = (id: string) => {
+    moveToTop(id);
+    moveToTop(kmCircleId(id));
+    moveToTop(kmLabelId(id));
+  };
+
+  // Per-layer hover/click handlers active in 'raiseOnHover' mode.
+  let lineEventBindings: {
+    event: 'mouseenter' | 'mouseleave' | 'click';
+    id: string;
+    fn: () => void;
+  }[] = [];
+
+  const clearLineEvents = () => {
+    lineEventBindings.forEach(({ event, id, fn }) => map.off(event, id, fn));
+    lineEventBindings = [];
+  };
+
+  /**
+   * Applies the current layer-stacking mode to the trail layers (and wires up the
+   * hover/tap handlers for 'raiseOnHover').
+   */
+  const applyLayerMode = () => {
+    clearLineEvents();
+    const mode = get(routeTweaks).routeLayerMode;
+    const ids = get(fileDataLayers)
+      .map((layer) => layer.id)
+      .filter((id) => map.getLayer(id));
+
+    if (mode === 'kmOnTop') {
+      // All lines first, then all km circles, then all km labels => markers on top.
+      ids.forEach((id) => moveToTop(id));
+      ids.forEach((id) => moveToTop(kmCircleId(id)));
+      ids.forEach((id) => moveToTop(kmLabelId(id)));
+      return;
+    }
+
+    // 'default' and 'raiseOnHover' share the per-route interleaved base order.
+    ids.forEach((id) => raiseTrail(id));
+
+    if (mode === 'raiseOnHover') {
+      ids.forEach((id) => {
+        const enter = () => {
+          raiseTrail(id);
+          map.getCanvas().style.cursor = 'pointer';
+        };
+        const leave = () => {
+          map.getCanvas().style.cursor = '';
+        };
+        const click = () => raiseTrail(id);
+        map.on('mouseenter', id, enter);
+        map.on('mouseleave', id, leave);
+        map.on('click', id, click);
+        lineEventBindings.push(
+          { event: 'mouseenter', id, fn: enter },
+          { event: 'mouseleave', id, fn: leave },
+          { event: 'click', id, fn: click }
+        );
+      });
+    }
+  };
+
   /** Full reconcile of the map against the current trails + tweaks state. */
   const sync = () => {
     refreshEffective();
@@ -292,6 +359,9 @@
 
     // Rebuild the global (clustered) start/end markers from the current state.
     rebuildEndpointMarkers();
+
+    // Apply the chosen layer-stacking mode (ordering + hover/tap handlers).
+    applyLayerMode();
   };
 
   /**
@@ -335,6 +405,7 @@
     unsubscribeLayers();
     unsubscribeTweaks();
     map.off('zoom', onZoom);
+    clearLineEvents();
     // Guard against the map having been torn down already (e.g. on navigation away).
     try {
       endpointMarkers.forEach((marker) => marker.remove());

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -17,11 +17,14 @@
   import type { FileDataLayer } from '$lib/types/DataLayer';
   import type { FeatureCollection, Point } from 'geojson';
   import {
+    clusterEndpoints,
     colorForRoute,
+    computeEndpointStyle,
     computeKmMarkers,
     computeStartEnd,
     evaluateZoomInterval,
-    parseZoomIntervalConfig
+    parseZoomIntervalConfig,
+    type RouteEndpoint
   } from '$lib/util/map/routeStyle';
   import * as Sentry from '@sentry/sveltekit';
   import logger from '$lib/util/logger';
@@ -58,9 +61,11 @@
   const kmCircleId = (id: string) => `${id}__km-circle`;
   const kmLabelId = (id: string) => `${id}__km-label`;
 
-  // Track what we've rendered + the DOM markers we manage manually.
+  // Track rendered trail layers + the global set of endpoint DOM markers.
   const rendered = new Set<string>();
-  const endpointMarkers = new Map<string, { start?: Marker; end?: Marker }>();
+  let endpointMarkers: Marker[] = [];
+
+  const BASE_MARKER_SIZE = 24; // px, badge diameter at full size
 
   const fitToTrail = (geoJson: FileDataLayer['geoJson']) => {
     try {
@@ -82,63 +87,76 @@
     }
   };
 
-  const toggleMarker = (marker: Marker | undefined, visible: boolean) => {
-    if (marker) marker.getElement().style.display = visible ? '' : 'none';
-  };
-
   const createEndpointElement = (type: 'start' | 'end') => {
+    const svgBase = type === 'start' ? 12 : 11;
     const el = document.createElement('div');
+    // `display:flex` lives in the global .trail-endpoint rule below, because mapbox
+    // clears the inline `display` property it sets on marker elements.
     el.classList.add('trail-endpoint');
+    el.dataset.svgBase = `${svgBase}`;
     el.style.cssText =
-      'width:24px;height:24px;border-radius:50%;align-items:center;' +
-      'justify-content:center;line-height:0;border:2px solid #fff;box-sizing:border-box;' +
-      'box-shadow:0 1px 4px rgba(0,0,0,0.4);';
+      `width:${BASE_MARKER_SIZE}px;height:${BASE_MARKER_SIZE}px;border-radius:50%;` +
+      'align-items:center;justify-content:center;line-height:0;' +
+      'border:2px solid #fff;box-sizing:border-box;box-shadow:0 1px 4px rgba(0,0,0,0.4);';
     // Slightly transparent backgrounds; the end marker is a red-orange.
     el.style.background = type === 'start' ? 'rgba(27, 120, 55, 0.82)' : 'rgba(216, 67, 33, 0.82)';
     el.innerHTML =
       type === 'start'
         ? // Filled play (triangle) icon
-          '<svg width="12" height="12" viewBox="0 0 24 24" fill="#fff" ' +
+          `<svg width="${svgBase}" height="${svgBase}" viewBox="0 0 24 24" fill="#fff" ` +
           'style="display:block"><path d="M8 6v12l11-6z"/></svg>'
         : // Filled stop (square) icon
-          '<svg width="11" height="11" viewBox="0 0 24 24" fill="#fff" ' +
+          `<svg width="${svgBase}" height="${svgBase}" viewBox="0 0 24 24" fill="#fff" ` +
           'style="display:block"><rect x="5" y="5" width="14" height="14" rx="1.5"/></svg>';
     return el;
   };
 
-  const updateEndpointMarkers = (layer: FileDataLayer) => {
-    const ends = computeStartEnd(layer.geoJson);
-    let entry = endpointMarkers.get(layer.id);
-    if (!entry) {
-      entry = {};
-      endpointMarkers.set(layer.id, entry);
+  /** Applies the current zoom-based scale & opacity to all endpoint markers. */
+  const applyEndpointStyle = () => {
+    const { scale, opacity } = computeEndpointStyle(map.getZoom());
+    const size = BASE_MARKER_SIZE * scale;
+    for (const marker of endpointMarkers) {
+      const el = marker.getElement();
+      el.style.width = `${size}px`;
+      el.style.height = `${size}px`;
+      el.style.borderWidth = `${Math.max(1, 2 * scale)}px`;
+      el.style.opacity = `${opacity}`;
+      const svg = el.querySelector('svg');
+      if (svg) {
+        const svgSize = Number(el.dataset.svgBase ?? 12) * scale;
+        svg.setAttribute('width', `${svgSize}`);
+        svg.setAttribute('height', `${svgSize}`);
+      }
+    }
+  };
+
+  /**
+   * Rebuilds the global set of start/end markers from all *visible* trails, merging
+   * endpoints within 5 m of each other into a single midpoint start marker.
+   */
+  const rebuildEndpointMarkers = () => {
+    endpointMarkers.forEach((marker) => marker.remove());
+    endpointMarkers = [];
+
+    if (!get(routeTweaks).showStartEndMarkers) return;
+
+    const endpoints: RouteEndpoint[] = [];
+    for (const layer of get(fileDataLayers)) {
+      if (layer.visible === false) continue;
+      const ends = computeStartEnd(layer.geoJson);
+      if (!ends) continue;
+      endpoints.push({ type: 'start', lngLat: ends.start as [number, number] });
+      endpoints.push({ type: 'end', lngLat: ends.end as [number, number] });
     }
 
-    if (!ends) {
-      entry.start?.remove();
-      entry.end?.remove();
-      entry.start = entry.end = undefined;
-      return;
-    }
-
-    const startLngLat = ends.start as [number, number];
-    const endLngLat = ends.end as [number, number];
-
-    if (!entry.start) {
-      entry.start = new mapboxgl.Marker({ element: createEndpointElement('start') })
-        .setLngLat(startLngLat)
+    for (const ep of clusterEndpoints(endpoints)) {
+      const marker = new mapboxgl.Marker({ element: createEndpointElement(ep.type) })
+        .setLngLat(ep.lngLat)
         .addTo(map);
-    } else {
-      entry.start.setLngLat(startLngLat);
+      endpointMarkers.push(marker);
     }
 
-    if (!entry.end) {
-      entry.end = new mapboxgl.Marker({ element: createEndpointElement('end') })
-        .setLngLat(endLngLat)
-        .addTo(map);
-    } else {
-      entry.end.setLngLat(endLngLat);
-    }
+    applyEndpointStyle();
   };
 
   const applyVisibility = (layer: FileDataLayer, tweaks: RouteTweaks) => {
@@ -148,11 +166,6 @@
     const kmVisible = lineVisible && tweaks.showKmMarkers;
     setLayerVisibility(kmCircleId(layer.id), kmVisible);
     setLayerVisibility(kmLabelId(layer.id), kmVisible);
-
-    const endpointsVisible = lineVisible && tweaks.showStartEndMarkers;
-    const entry = endpointMarkers.get(layer.id);
-    toggleMarker(entry?.start, endpointsVisible);
-    toggleMarker(entry?.end, endpointsVisible);
   };
 
   const renderTrail = (layer: FileDataLayer, color: string, tweaks: RouteTweaks) => {
@@ -227,8 +240,7 @@
       map.setPaintProperty(kmLabelId(id), 'text-opacity', effOpacity);
     }
 
-    // --- Start/end markers ---
-    updateEndpointMarkers(layer);
+    // Start/end markers are managed globally (see rebuildEndpointMarkers).
 
     // --- Visibility ---
     applyVisibility(layer, tweaks);
@@ -242,11 +254,6 @@
     });
     if (map.getSource(kmSourceId(id))) map.removeSource(kmSourceId(id));
     if (map.getSource(id)) map.removeSource(id);
-
-    const entry = endpointMarkers.get(id);
-    entry?.start?.remove();
-    entry?.end?.remove();
-    endpointMarkers.delete(id);
 
     rendered.delete(id);
   };
@@ -268,6 +275,9 @@
       const color = colorForRoute(index, tweaks.useMultipleColors);
       renderTrail(layer, color, tweaks);
     });
+
+    // Rebuild the global (clustered) start/end markers from the current state.
+    rebuildEndpointMarkers();
   };
 
   /**
@@ -297,6 +307,9 @@
         map.setPaintProperty(kmLabelId(id), 'text-opacity', effOpacity);
       }
     });
+
+    // Shrink/fade the start/end markers based on zoom.
+    applyEndpointStyle();
   };
 
   map.on('zoom', onZoom);
@@ -310,6 +323,8 @@
     map.off('zoom', onZoom);
     // Guard against the map having been torn down already (e.g. on navigation away).
     try {
+      endpointMarkers.forEach((marker) => marker.remove());
+      endpointMarkers = [];
       [...rendered].forEach(removeTrail);
     } catch {
       // The map/style is gone; nothing left to clean up.

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -372,41 +372,59 @@
     lineEventBindings = [];
   };
 
+  const currentTrailIds = () =>
+    get(fileDataLayers)
+      .map((layer) => layer.id)
+      .filter((id) => map.getLayer(id));
+
+  /** Moves the overlap lines and all km marker layers above everything else. */
+  const stackKmOnTop = () => {
+    moveToTop(OVERLAP_LAYER_A);
+    moveToTop(OVERLAP_LAYER_B);
+    currentTrailIds().forEach((id) => moveToTop(kmCircleId(id)));
+    currentTrailIds().forEach((id) => moveToTop(kmLabelId(id)));
+  };
+
   /**
    * Applies the current layer-stacking mode to the trail layers (and wires up the
-   * hover/tap handlers for 'raiseOnHover').
+   * hover/tap handlers for the raise modes).
    */
   const applyLayerMode = () => {
     clearLineEvents();
     const mode = get(routeTweaks).routeLayerMode;
-    const ids = get(fileDataLayers)
-      .map((layer) => layer.id)
-      .filter((id) => map.getLayer(id));
+    const ids = currentTrailIds();
 
     const kmOnTop = mode === 'kmOnTop' || mode === 'kmOnTopHover' || mode === 'kmOnTopOverlap';
 
     if (kmOnTop) {
       // Lines first, then overlap lines, then all km circles & labels => markers on top.
       ids.forEach((id) => moveToTop(id));
-      moveToTop(OVERLAP_LAYER_A);
-      moveToTop(OVERLAP_LAYER_B);
-      ids.forEach((id) => moveToTop(kmCircleId(id)));
-      ids.forEach((id) => moveToTop(kmLabelId(id)));
+      stackKmOnTop();
     } else {
       // 'default' and 'raiseOnHover' share the per-route interleaved base order.
       ids.forEach((id) => raiseTrail(id));
     }
 
     if (mode === 'raiseOnHover' || mode === 'kmOnTopHover') {
+      // In 'kmOnTopHover' only the stroke is raised (km markers must stay on top);
+      // in 'raiseOnHover' the whole route (stroke + its km markers) is raised.
+      const raise =
+        mode === 'kmOnTopHover'
+          ? (id: string) => {
+              moveToTop(id);
+              stackKmOnTop();
+            }
+          : (id: string) => raiseTrail(id);
+
       ids.forEach((id) => {
         const enter = () => {
-          raiseTrail(id);
+          raise(id);
           map.getCanvas().style.cursor = 'pointer';
         };
         const leave = () => {
           map.getCanvas().style.cursor = '';
         };
-        const click = () => raiseTrail(id);
+        const click = () => raise(id);
         map.on('mouseenter', id, enter);
         map.on('mouseleave', id, leave);
         map.on('click', id, click);

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -1,171 +1,247 @@
 <script lang="ts">
   import type { ContextType } from './Map.svelte';
-  import type GeoJSON from 'geojson';
-  import { fileDataLayers, prefix } from '$lib/stores/file';
-  import { getContext } from 'svelte';
+  import type { GeoJSONSource, Marker } from 'mapbox-gl';
+  import mapboxgl from 'mapbox-gl';
+  import { fileDataLayers } from '$lib/stores/file';
+  import { routeTweaks, type RouteTweaks } from '$lib/stores/routeTweaks';
+  import { getContext, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import { bbox } from '@turf/bbox';
   import key from './mapbox-context.js';
   import { ZOOM_LEVELS } from '$lib/constants';
   import type { FileDataLayer } from '$lib/types/DataLayer';
+  import { colorForRoute, computeKmMarkers, computeStartEnd } from '$lib/util/map/routeStyle';
   import * as Sentry from '@sentry/sveltekit';
   import logger from '$lib/util/logger';
-
-  type SourceData =
-    | string
-    | GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>
-    | GeoJSON.FeatureCollection<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>
-    | undefined;
 
   const { getMap } = getContext<ContextType>(key);
   const map = getMap();
 
-  const updateVisibility = (id: string, visible?: boolean) => {
-    const layer = map.getLayer(id);
-    if (layer) {
-      if (visible) map.setLayoutProperty(id, 'visibility', 'visible');
-      else map.setLayoutProperty(id, 'visibility', 'none');
+  // Layer/source id helpers (the base `id` stays the line layer/source, for backwards compat).
+  const kmSourceId = (id: string) => `${id}__km`;
+  const kmCircleId = (id: string) => `${id}__km-circle`;
+  const kmLabelId = (id: string) => `${id}__km-label`;
+
+  // Track what we've rendered + the DOM markers we manage manually.
+  const rendered = new Set<string>();
+  const endpointMarkers = new Map<
+    string,
+    { start?: Marker; end?: Marker }
+  >();
+
+  const fitToTrail = (geoJson: FileDataLayer['geoJson']) => {
+    try {
+      const bboxBounds = <[number, number, number, number]>bbox(geoJson).slice(0, 4);
+      map.fitBounds(bboxBounds, {
+        padding: { top: 150, bottom: 150, left: 50, right: 50 },
+        maxZoom: ZOOM_LEVELS.ROAD,
+        linear: true
+      });
+    } catch (error) {
+      logger.error(error);
+      Sentry.captureException(error, { extra: { context: 'Adding trail' } });
     }
   };
 
-  const addTrail = ({ geoJson, id, animate }: FileDataLayer) => {
-    // Zoom & pan the map to show the trail, but only if we added the route locally.
-    if (animate) {
-      try {
-        const bboxBounds = <[number, number, number, number]>bbox(geoJson).slice(0, 4);
-        map.fitBounds(bboxBounds, {
-          padding: {
-            top: 150,
-            bottom: 150,
-            left: 50,
-            right: 50
-          },
-          maxZoom: ZOOM_LEVELS.ROAD,
-          linear: true
-        });
-      } catch (error) {
-        logger.error(error);
-        Sentry.captureException(error, { extra: { context: 'Adding trail' } });
-      }
+  const setLayerVisibility = (id: string, visible: boolean) => {
+    if (map.getLayer(id)) {
+      map.setLayoutProperty(id, 'visibility', visible ? 'visible' : 'none');
+    }
+  };
+
+  const toggleMarker = (marker: Marker | undefined, visible: boolean) => {
+    if (marker) marker.getElement().style.display = visible ? '' : 'none';
+  };
+
+  const createEndpointElement = (type: 'start' | 'end') => {
+    const el = document.createElement('div');
+    el.style.cssText =
+      'width:24px;height:24px;border-radius:50%;display:flex;align-items:center;' +
+      'justify-content:center;border:2px solid #fff;box-sizing:border-box;' +
+      'box-shadow:0 1px 4px rgba(0,0,0,0.4);';
+    el.style.background = type === 'start' ? '#1b7837' : '#c1121f';
+    el.innerHTML =
+      type === 'start'
+        ? // Flag icon
+          '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#fff" ' +
+          'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
+          '<path d="M4 22V4"/><path d="M4 4h13l-2 4 2 4H4"/></svg>'
+        : // Checkered (finish) icon
+          '<svg width="13" height="13" viewBox="0 0 16 16">' +
+          '<rect x="0" y="0" width="8" height="8" fill="#fff"/>' +
+          '<rect x="8" y="8" width="8" height="8" fill="#fff"/></svg>';
+    return el;
+  };
+
+  const updateEndpointMarkers = (layer: FileDataLayer) => {
+    const ends = computeStartEnd(layer.geoJson);
+    let entry = endpointMarkers.get(layer.id);
+    if (!entry) {
+      entry = {};
+      endpointMarkers.set(layer.id, entry);
     }
 
-    // Add/update layer data
-    if (map.getSource(id)) {
-      map.getSource(id).setData(geoJson);
+    if (!ends) {
+      entry.start?.remove();
+      entry.end?.remove();
+      entry.start = entry.end = undefined;
+      return;
+    }
+
+    const startLngLat = ends.start as [number, number];
+    const endLngLat = ends.end as [number, number];
+
+    if (!entry.start) {
+      entry.start = new mapboxgl.Marker({ element: createEndpointElement('start') })
+        .setLngLat(startLngLat)
+        .addTo(map);
     } else {
-      map.addSource(id, {
-        type: 'geojson',
-        data: geoJson
-      });
+      entry.start.setLngLat(startLngLat);
     }
 
-    // Add a presentation if not existing yet
+    if (!entry.end) {
+      entry.end = new mapboxgl.Marker({ element: createEndpointElement('end') })
+        .setLngLat(endLngLat)
+        .addTo(map);
+    } else {
+      entry.end.setLngLat(endLngLat);
+    }
+  };
+
+  const applyVisibility = (layer: FileDataLayer, tweaks: RouteTweaks) => {
+    const lineVisible = layer.visible !== false;
+    setLayerVisibility(layer.id, lineVisible);
+
+    const kmVisible = lineVisible && tweaks.showKmMarkers;
+    setLayerVisibility(kmCircleId(layer.id), kmVisible);
+    setLayerVisibility(kmLabelId(layer.id), kmVisible);
+
+    const endpointsVisible = lineVisible && tweaks.showStartEndMarkers;
+    const entry = endpointMarkers.get(layer.id);
+    toggleMarker(entry?.start, endpointsVisible);
+    toggleMarker(entry?.end, endpointsVisible);
+  };
+
+  const renderTrail = (layer: FileDataLayer, color: string, tweaks: RouteTweaks) => {
+    const { id, geoJson } = layer;
+    const isNew = !map.getSource(id);
+
+    // --- Route line ---
+    if (isNew) {
+      map.addSource(id, { type: 'geojson', data: geoJson });
+    } else {
+      (map.getSource(id) as GeoJSONSource | undefined)?.setData(geoJson);
+    }
+
     if (!map.getLayer(id)) {
       map.addLayer({
         id,
         type: 'line',
         source: id,
-        layout: {
-          'line-join': 'round',
-          'line-cap': 'round'
-        },
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-width': 7, 'line-color': color, 'line-opacity': 0.8 }
+      });
+    } else {
+      map.setPaintProperty(id, 'line-color', color);
+    }
+
+    // Zoom to the trail only when we just added it locally.
+    if (isNew && layer.animate) fitToTrail(geoJson);
+
+    // --- Kilometre markers ---
+    const kmData = computeKmMarkers(geoJson, tweaks.kmInterval);
+    if (!map.getSource(kmSourceId(id))) {
+      map.addSource(kmSourceId(id), { type: 'geojson', data: kmData });
+    } else {
+      (map.getSource(kmSourceId(id)) as GeoJSONSource | undefined)?.setData(kmData);
+    }
+
+    if (!map.getLayer(kmCircleId(id))) {
+      map.addLayer({
+        id: kmCircleId(id),
+        type: 'circle',
+        source: kmSourceId(id),
         paint: {
-          'line-width': 7,
-          'line-color': 'indigo',
-          'line-opacity': 0.7
+          'circle-color': 'rgba(255, 255, 255, 0.75)',
+          'circle-radius': 9,
+          'circle-stroke-width': 1.5,
+          'circle-stroke-color': color
         }
       });
+    } else {
+      map.setPaintProperty(kmCircleId(id), 'circle-stroke-color', color);
     }
+
+    if (!map.getLayer(kmLabelId(id))) {
+      map.addLayer({
+        id: kmLabelId(id),
+        type: 'symbol',
+        source: kmSourceId(id),
+        layout: {
+          'text-field': ['get', 'label'],
+          'text-size': 10,
+          'text-allow-overlap': true,
+          'text-ignore-placement': true
+        },
+        paint: { 'text-color': color }
+      });
+    } else {
+      map.setPaintProperty(kmLabelId(id), 'text-color', color);
+    }
+
+    // --- Start/end markers ---
+    updateEndpointMarkers(layer);
+
+    // --- Visibility ---
+    applyVisibility(layer, tweaks);
+
+    rendered.add(id);
   };
 
-  const getFileDataLayerIdsOnMap = () => {
-    const fileDataLayerIdsOnMap: string[] = [];
-
-    map.getStyle().layers?.map((layer) => {
-      if (layer.id.includes(prefix)) {
-        // Instead of returning the layer ID, we could return the layer object
-
-        // const fileDataLayer: FileDataLayer = {
-        //   id: layer.id,
-        //   name: layer.id,
-        //   visible: layer.layout?.visibility === 'visible',
-        //   geoJson: map.getSource(layer.id)?.data
-        // };
-
-        fileDataLayerIdsOnMap.push(layer.id);
-      }
+  const removeTrail = (id: string) => {
+    [kmLabelId(id), kmCircleId(id), id].forEach((layerId) => {
+      if (map.getLayer(layerId)) map.removeLayer(layerId);
     });
+    if (map.getSource(kmSourceId(id))) map.removeSource(kmSourceId(id));
+    if (map.getSource(id)) map.removeSource(id);
 
-    return fileDataLayerIdsOnMap;
+    const entry = endpointMarkers.get(id);
+    entry?.start?.remove();
+    entry?.end?.remove();
+    endpointMarkers.delete(id);
+
+    rendered.delete(id);
   };
 
-  const setup = async (geoJson?: SourceData) => {
-    map.addSource('trail', {
-      type: 'geojson',
-      data: geoJson || {
-        type: 'FeatureCollection',
-        features: []
-      }
+  /** Full reconcile of the map against the current trails + tweaks state. */
+  const sync = () => {
+    const layers = get(fileDataLayers);
+    const tweaks = get(routeTweaks);
+
+    const wantedIds = new Set(layers.map((layer) => layer.id));
+    // Remove trails that are no longer present.
+    [...rendered].forEach((id) => {
+      if (!wantedIds.has(id)) removeTrail(id);
     });
 
-    map.addLayer({
-      id: 'trail-line',
-      source: 'trail',
-      type: 'line',
-      paint: {
-        'line-width': 7,
-        'line-color': 'indigo',
-        'line-opacity': 0.7
-      }
-    });
-    map.addLayer({
-      id: 'trail-points',
-      source: 'trail',
-      type: 'circle',
-      paint: {
-        'circle-color': 'indigo',
-        'circle-radius': 7,
-        'circle-opacity': 0.9,
-        'circle-stroke-color': '#333',
-        'circle-stroke-width': 0.5
-      }
+    // Add/update remaining trails. Index drives the alternating colour.
+    layers.forEach((layer, index) => {
+      const color = colorForRoute(index, tweaks.useMultipleColors);
+      renderTrail(layer, color, tweaks);
     });
   };
 
-  let prevFileDataLayerIds: string[] = [];
+  const unsubscribeLayers = fileDataLayers.subscribe(sync);
+  const unsubscribeTweaks = routeTweaks.subscribe(sync);
 
-  // Subscribe to fileDataLayers store and update map layers accordingly when it changes (e.g. when a new file is loaded)
-  fileDataLayers.subscribe((fileDataLayers) => {
-    const fileDataLayerIds = fileDataLayers.map((fileDataLayer) => fileDataLayer.id);
-
-    // TODO: Discussion
-    // We should get the prevFileDataLayerIds from the map, not from the variable; otherwise, we might miss layers that were added to the map
-    // but not yet added to the store (e.g. when a new file is loaded)
-    // fileDataLayerIds = getFileDataLayerIdsOnMap();
-
-    const idsToAdd = fileDataLayerIds.filter((id) => !prevFileDataLayerIds.includes(id)); // IDs that are in the new data, but not in the old data
-    const idsToRemove = prevFileDataLayerIds.filter((id) => !fileDataLayerIds.includes(id)); // IDs that are in the old data, but not in the new data
-    const idsToUpdate = fileDataLayerIds.filter((id) => prevFileDataLayerIds.includes(id)); // IDs that are in both the old and new data
-
-    // Check
-
-    // Add new layers
-    idsToAdd.map((id) => {
-      const fileDataLayer = fileDataLayers.find((fileDataLayer) => fileDataLayer.id === id);
-      if (fileDataLayer) addTrail(fileDataLayer);
-    });
-
-    // Remove old layers
-    idsToRemove.map((id) => {
-      if (map.getLayer(id)) map.removeLayer(id);
-      if (map.getSource(id)) map.removeSource(id);
-    });
-
-    // Update visibility of existing layers
-    idsToUpdate.map((id) => {
-      const fileDataLayer = fileDataLayers.find((fileDataLayer) => fileDataLayer.id === id);
-      if (fileDataLayer) updateVisibility(id, fileDataLayer.visible);
-    });
-
-    prevFileDataLayerIds = fileDataLayerIds;
+  onDestroy(() => {
+    unsubscribeLayers();
+    unsubscribeTweaks();
+    // Guard against the map having been torn down already (e.g. on navigation away).
+    try {
+      [...rendered].forEach(removeTrail);
+    } catch {
+      // The map/style is gone; nothing left to clean up.
+    }
   });
 </script>

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -24,10 +24,7 @@
 
   // Track what we've rendered + the DOM markers we manage manually.
   const rendered = new Set<string>();
-  const endpointMarkers = new Map<
-    string,
-    { start?: Marker; end?: Marker }
-  >();
+  const endpointMarkers = new Map<string, { start?: Marker; end?: Marker }>();
 
   const fitToTrail = (geoJson: FileDataLayer['geoJson']) => {
     try {

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -6,6 +6,7 @@
   import {
     routeTweaks,
     type RouteTweaks,
+    type EndpointMode,
     currentMapZoom,
     effectiveKm
   } from '$lib/stores/routeTweaks';
@@ -108,17 +109,45 @@
     }
   } as const;
 
-  const createEndpointElement = (type: RouteEndpoint['type']) => {
-    const { svgBase, background, icon } = ENDPOINT_CONFIG[type];
+  // A 4×4 black/white checkerboard filling the badge, clipped to the circle — a
+  // finish flag. Stretched to fill via preserveAspectRatio="none".
+  const CHECKERBOARD_SVG =
+    '<svg viewBox="0 0 4 4" preserveAspectRatio="none" width="100%" height="100%" ' +
+    'fill="#111" style="display:block"><rect width="4" height="4" fill="#fff"/>' +
+    [0, 1, 2, 3]
+      .flatMap((r) =>
+        [0, 1, 2, 3]
+          .filter((c) => (r + c) % 2 === 0)
+          .map((c) => `<rect x="${c}" y="${r}" width="1" height="1"/>`)
+      )
+      .join('') +
+    '</svg>';
+
+  const createEndpointElement = (type: RouteEndpoint['type'], mode: EndpointMode) => {
     const el = document.createElement('div');
     // `display:flex` lives in the global .trail-endpoint rule below, because mapbox
     // clears the inline `display` property it sets on marker elements.
     el.classList.add('trail-endpoint');
-    el.dataset.svgBase = `${svgBase}`;
     el.style.cssText =
       `width:${BASE_MARKER_SIZE}px;height:${BASE_MARKER_SIZE}px;border-radius:50%;` +
-      'align-items:center;justify-content:center;line-height:0;' +
+      'align-items:center;justify-content:center;line-height:0;overflow:hidden;' +
       'border:2px solid #fff;box-sizing:border-box;box-shadow:0 1px 4px rgba(0,0,0,0.4);';
+
+    if (mode === 'flags') {
+      if (type === 'start') {
+        // Plain, mostly-opaque green circle (no icon).
+        el.style.background = 'rgba(27, 120, 55, 0.92)';
+      } else {
+        // End & merged (pause) => checkerboard finish badge.
+        el.style.background = '#fff';
+        el.innerHTML = CHECKERBOARD_SVG;
+      }
+      return el;
+    }
+
+    // 'icons' mode (status quo): play / stop / pause glyphs.
+    const { svgBase, background, icon } = ENDPOINT_CONFIG[type];
+    el.dataset.svgBase = `${svgBase}`;
     el.style.background = background;
     el.innerHTML =
       `<svg width="${svgBase}" height="${svgBase}" viewBox="0 0 24 24" fill="#fff" ` +
@@ -136,9 +165,11 @@
       el.style.height = `${size}px`;
       el.style.borderWidth = `${Math.max(1, 2 * scale)}px`;
       el.style.opacity = `${opacity}`;
+      // Only fixed-size glyph svgs are resized; the checkerboard svg fills the badge
+      // (width/height 100%) and scales automatically with it.
       const svg = el.querySelector('svg');
-      if (svg) {
-        const svgSize = Number(el.dataset.svgBase ?? 12) * scale;
+      if (svg && el.dataset.svgBase) {
+        const svgSize = Number(el.dataset.svgBase) * scale;
         svg.setAttribute('width', `${svgSize}`);
         svg.setAttribute('height', `${svgSize}`);
       }
@@ -154,6 +185,7 @@
     endpointMarkers = [];
 
     if (!get(routeTweaks).showStartEndMarkers) return;
+    const mode = get(routeTweaks).endpointMode;
 
     const endpoints: RouteEndpoint[] = [];
     for (const layer of get(fileDataLayers)) {
@@ -165,7 +197,7 @@
     }
 
     for (const ep of clusterEndpoints(endpoints)) {
-      const marker = new mapboxgl.Marker({ element: createEndpointElement(ep.type) })
+      const marker = new mapboxgl.Marker({ element: createEndpointElement(ep.type, mode) })
         .setLngLat(ep.lngLat)
         .addTo(map);
       endpointMarkers.push(marker);

--- a/src/lib/components/Map/FileTrails.svelte
+++ b/src/lib/components/Map/FileTrails.svelte
@@ -21,6 +21,7 @@
     colorForRoute,
     computeEndpointStyle,
     computeKmMarkers,
+    computeOverlapSegments,
     computeStartEnd,
     evaluateZoomInterval,
     parseZoomIntervalConfig,
@@ -283,6 +284,82 @@
     moveToTop(kmLabelId(id));
   };
 
+  // Shared-segment overlap layers (only used in 'kmOnTopOverlap' mode).
+  const OVERLAP_SOURCE = '__route-overlaps';
+  const OVERLAP_LAYER_A = '__route-overlaps-a';
+  const OVERLAP_LAYER_B = '__route-overlaps-b';
+
+  // Signature of the inputs the last overlap computation was based on, so the
+  // (expensive) scan is skipped when unrelated tweaks change (e.g. km config edits).
+  let lastOverlapSig = '';
+
+  const removeOverlapLayers = () => {
+    [OVERLAP_LAYER_B, OVERLAP_LAYER_A].forEach((id) => {
+      if (map.getLayer(id)) map.removeLayer(id);
+    });
+    if (map.getSource(OVERLAP_SOURCE)) map.removeSource(OVERLAP_SOURCE);
+    lastOverlapSig = '';
+  };
+
+  /**
+   * In overlap mode, detects where routes share the same path and draws those stretches
+   * as a single line alternating the two routes' colours (solid colour A + dashed
+   * colour B on top). No-op / cleanup in other modes.
+   */
+  const applyOverlaps = () => {
+    if (get(routeTweaks).routeLayerMode !== 'kmOnTopOverlap') {
+      removeOverlapLayers();
+      return;
+    }
+
+    const tweaks = get(routeTweaks);
+    const routes = get(fileDataLayers)
+      .map((layer, index) => ({
+        id: layer.id,
+        color: colorForRoute(index, tweaks.useMultipleColors),
+        geoJson: layer.geoJson,
+        visible: layer.visible !== false
+      }))
+      .filter((r) => r.visible);
+
+    // Recompute only when the routes or their colours actually changed.
+    const sig = routes.map((r) => `${r.id}:${r.color}`).join(',');
+    if (sig === lastOverlapSig && map.getSource(OVERLAP_SOURCE)) return;
+    lastOverlapSig = sig;
+
+    const data = computeOverlapSegments(routes);
+
+    if (!map.getSource(OVERLAP_SOURCE)) {
+      map.addSource(OVERLAP_SOURCE, { type: 'geojson', data });
+    } else {
+      (map.getSource(OVERLAP_SOURCE) as GeoJSONSource | undefined)?.setData(data);
+    }
+
+    if (!map.getLayer(OVERLAP_LAYER_A)) {
+      map.addLayer({
+        id: OVERLAP_LAYER_A,
+        type: 'line',
+        source: OVERLAP_SOURCE,
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-width': 7, 'line-color': ['get', 'colorA'], 'line-opacity': 0.9 }
+      });
+    }
+    if (!map.getLayer(OVERLAP_LAYER_B)) {
+      map.addLayer({
+        id: OVERLAP_LAYER_B,
+        type: 'line',
+        source: OVERLAP_SOURCE,
+        layout: { 'line-join': 'round', 'line-cap': 'butt' },
+        paint: {
+          'line-width': 7,
+          'line-color': ['get', 'colorB'],
+          'line-opacity': 0.9,
+          'line-dasharray': [2, 2]
+        }
+      });
+    }
+  };
+
   // Per-layer hover/click handlers active in 'raiseOnHover' mode.
   let lineEventBindings: {
     event: 'mouseenter' | 'mouseleave' | 'click';
@@ -306,18 +383,21 @@
       .map((layer) => layer.id)
       .filter((id) => map.getLayer(id));
 
-    if (mode === 'kmOnTop') {
-      // All lines first, then all km circles, then all km labels => markers on top.
+    const kmOnTop = mode === 'kmOnTop' || mode === 'kmOnTopHover' || mode === 'kmOnTopOverlap';
+
+    if (kmOnTop) {
+      // Lines first, then overlap lines, then all km circles & labels => markers on top.
       ids.forEach((id) => moveToTop(id));
+      moveToTop(OVERLAP_LAYER_A);
+      moveToTop(OVERLAP_LAYER_B);
       ids.forEach((id) => moveToTop(kmCircleId(id)));
       ids.forEach((id) => moveToTop(kmLabelId(id)));
-      return;
+    } else {
+      // 'default' and 'raiseOnHover' share the per-route interleaved base order.
+      ids.forEach((id) => raiseTrail(id));
     }
 
-    // 'default' and 'raiseOnHover' share the per-route interleaved base order.
-    ids.forEach((id) => raiseTrail(id));
-
-    if (mode === 'raiseOnHover') {
+    if (mode === 'raiseOnHover' || mode === 'kmOnTopHover') {
       ids.forEach((id) => {
         const enter = () => {
           raiseTrail(id);
@@ -359,6 +439,9 @@
 
     // Rebuild the global (clustered) start/end markers from the current state.
     rebuildEndpointMarkers();
+
+    // Build/refresh shared-segment overlap layers (overlap mode only).
+    applyOverlaps();
 
     // Apply the chosen layer-stacking mode (ordering + hover/tap handlers).
     applyLayerMode();
@@ -410,6 +493,7 @@
     try {
       endpointMarkers.forEach((marker) => marker.remove());
       endpointMarkers = [];
+      removeOverlapLayers();
       [...rendered].forEach(removeTrail);
     } catch {
       // The map/style is gone; nothing left to clean up.

--- a/src/lib/components/Map/RouteTweaks.svelte
+++ b/src/lib/components/Map/RouteTweaks.svelte
@@ -5,7 +5,12 @@
    * NOTE: this is a one-off, self-contained tweaks panel. It can be removed together with
    * `$lib/stores/routeTweaks` and the related handling in `FileTrails.svelte`.
    */
-  import { routeTweaks, currentMapZoom, effectiveKm } from '$lib/stores/routeTweaks';
+  import {
+    routeTweaks,
+    currentMapZoom,
+    effectiveKm,
+    type RouteLayerMode
+  } from '$lib/stores/routeTweaks';
   import { ROUTE_COLORS, DEFAULT_ZOOM_INTERVAL_CONFIG } from '$lib/util/map/routeStyle';
   import { Switch, Modal } from '$lib/components/UI';
   import Icon from '$lib/components/UI/Icon.svelte';
@@ -17,6 +22,12 @@
     routeTweaks.update((t) => ({ ...t, [key]: !t[key] }));
 
   const setPanelOpen = (panelOpen: boolean) => routeTweaks.update((t) => ({ ...t, panelOpen }));
+
+  const onLayerModeChange = (e: Event) =>
+    routeTweaks.update((t) => ({
+      ...t,
+      routeLayerMode: (e.currentTarget as HTMLSelectElement).value as RouteLayerMode
+    }));
 
   const onConfigInput = (e: Event) =>
     routeTweaks.update((t) => ({
@@ -89,6 +100,15 @@
         ariaLabel="Toggle start and end markers"
         onToggle={() => toggle('showStartEndMarkers')}
       />
+    </div>
+
+    <div class="row">
+      <label class="label" for="layer-mode">Overlapping routes</label>
+      <select id="layer-mode" value={$routeTweaks.routeLayerMode} onchange={onLayerModeChange}>
+        <option value="default">Default</option>
+        <option value="kmOnTop">Km markers on top</option>
+        <option value="raiseOnHover">Raise route on hover/tap</option>
+      </select>
     </div>
   </section>
 {:else}
@@ -204,6 +224,16 @@
 
   .readouts .muted {
     color: var(--color-text-light, #777);
+  }
+
+  select {
+    font-size: 1.3rem;
+    padding: 0.3rem 0.4rem;
+    border: 1px solid var(--color-gray, #ccc);
+    border-radius: 0.4rem;
+    background: #fff;
+    cursor: pointer;
+    max-width: 14rem;
   }
 
   .link-button {

--- a/src/lib/components/Map/RouteTweaks.svelte
+++ b/src/lib/components/Map/RouteTweaks.svelte
@@ -5,23 +5,38 @@
    * NOTE: this is a one-off, self-contained tweaks panel. It can be removed together with
    * `$lib/stores/routeTweaks` and the related handling in `FileTrails.svelte`.
    */
-  import { routeTweaks } from '$lib/stores/routeTweaks';
-  import { ROUTE_COLORS } from '$lib/util/map/routeStyle';
-  import { Switch } from '$lib/components/UI';
+  import { routeTweaks, currentMapZoom, effectiveKm } from '$lib/stores/routeTweaks';
+  import { ROUTE_COLORS, DEFAULT_ZOOM_INTERVAL_CONFIG } from '$lib/util/map/routeStyle';
+  import { Switch, Modal } from '$lib/components/UI';
   import Icon from '$lib/components/UI/Icon.svelte';
   import { crossIcon } from '$lib/images/icons';
+
+  let showIntervalModal = $state(false);
 
   const toggle = (key: 'useMultipleColors' | 'showKmMarkers' | 'showStartEndMarkers') =>
     routeTweaks.update((t) => ({ ...t, [key]: !t[key] }));
 
-  const onIntervalInput = (e: Event) => {
-    const value = parseFloat((e.currentTarget as HTMLInputElement).value);
-    if (!Number.isNaN(value) && value > 0) {
-      routeTweaks.update((t) => ({ ...t, kmInterval: value }));
-    }
-  };
-
   const setPanelOpen = (panelOpen: boolean) => routeTweaks.update((t) => ({ ...t, panelOpen }));
+
+  const onConfigInput = (e: Event) =>
+    routeTweaks.update((t) => ({
+      ...t,
+      zoomIntervalConfig: (e.currentTarget as HTMLTextAreaElement).value
+    }));
+
+  const resetConfig = () =>
+    routeTweaks.update((t) => ({ ...t, zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG }));
+
+  let zoomText = $derived($currentMapZoom != null ? $currentMapZoom.toFixed(1) : '—');
+  let intervalText = $derived(
+    !$routeTweaks.showKmMarkers
+      ? 'off'
+      : !$effectiveKm
+        ? 'hidden'
+        : $effectiveKm.opacity < 1
+          ? `${$effectiveKm.interval} km (fading)`
+          : `${$effectiveKm.interval} km`
+  );
 </script>
 
 {#if $routeTweaks.panelOpen}
@@ -59,18 +74,13 @@
       />
     </div>
 
-    <div class="row">
-      <label class="label" for="km-interval">Km marker interval</label>
-      <input
-        id="km-interval"
-        type="number"
-        min="0.1"
-        step="0.1"
-        value={$routeTweaks.kmInterval}
-        oninput={onIntervalInput}
-        disabled={!$routeTweaks.showKmMarkers}
-      />
+    <div class="readouts">
+      <div><span class="muted">Zoom level</span> <strong>{zoomText}</strong></div>
+      <div><span class="muted">Interval</span> <strong>{intervalText}</strong></div>
     </div>
+    <button class="link-button" onclick={() => (showIntervalModal = true)}>
+      Edit zoom → interval rules…
+    </button>
 
     <div class="row">
       <span class="label">Show start/end markers</span>
@@ -84,6 +94,42 @@
 {:else}
   <button class="route-tweaks-reopen" onclick={() => setPanelOpen(true)}> Route tweaks </button>
 {/if}
+
+<Modal
+  bind:show={showIntervalModal}
+  maxWidth="42rem"
+  center
+  closeButton
+  ariaLabel="Edit zoom to interval rules"
+>
+  {#snippet body()}
+    <div class="config-modal">
+      <h3>Zoom → km interval rules</h3>
+      <p class="help">
+        One rule per line: <code>&lt;min&gt;-&lt;max&gt;,&lt;intervalKm&gt;</code>. Omit
+        <code>max</code> for an open upper bound. Floats allowed. Lines apply at zoom in
+        <code>[min, max)</code>. Below the lowest rule the markers fade out.
+      </p>
+      <p class="help example">
+        e.g. <code>11-,1</code> = 1&nbsp;km from zoom 11; <code>7-8,10</code> = 10&nbsp;km between zoom
+        7 and 8.
+      </p>
+      <textarea
+        class="config-input"
+        rows="6"
+        spellcheck="false"
+        value={$routeTweaks.zoomIntervalConfig}
+        oninput={onConfigInput}
+      ></textarea>
+      <div class="config-status">
+        Current zoom <strong>{zoomText}</strong> → interval <strong>{intervalText}</strong>
+      </div>
+    </div>
+  {/snippet}
+  {#snippet controls()}
+    <button class="reset-button" onclick={resetConfig}>Reset to default</button>
+  {/snippet}
+</Modal>
 
 <style>
   .route-tweaks {
@@ -149,17 +195,25 @@
     line-height: 1.3;
   }
 
-  input[type='number'] {
-    width: 6rem;
-    padding: 0.4rem 0.5rem;
-    border: 1px solid var(--color-gray, #ccc);
-    border-radius: 0.4rem;
-    font-size: 1.4rem;
-    text-align: right;
+  .readouts {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.4rem 0 0.2rem;
   }
 
-  input[type='number']:disabled {
-    opacity: 0.5;
+  .readouts .muted {
+    color: var(--color-text-light, #777);
+  }
+
+  .link-button {
+    background: none;
+    border: none;
+    padding: 0.2rem 0 0.6rem;
+    color: var(--color-highlight-blue, #1565c0);
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: 1.3rem;
   }
 
   .legend {
@@ -188,5 +242,55 @@
     font-size: 1.3rem;
     font-weight: 600;
     cursor: pointer;
+  }
+
+  .config-modal h3 {
+    font-size: 1.7rem;
+    margin: 0 0 0.8rem;
+  }
+
+  .config-modal .help {
+    font-size: 1.3rem;
+    line-height: 1.4;
+    margin: 0 0 0.6rem;
+    color: var(--color-text, #333);
+  }
+
+  .config-modal .example {
+    color: var(--color-text-light, #777);
+  }
+
+  .config-modal code {
+    background: var(--color-gray-fa, #f2f2f2);
+    border-radius: 0.3rem;
+    padding: 0.05rem 0.3rem;
+    font-family: monospace;
+  }
+
+  .config-input {
+    width: 100%;
+    box-sizing: border-box;
+    font-family: monospace;
+    font-size: 1.4rem;
+    line-height: 1.5;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--color-gray, #ccc);
+    border-radius: 0.4rem;
+    resize: vertical;
+  }
+
+  .config-status {
+    margin-top: 0.8rem;
+    font-size: 1.3rem;
+    color: var(--color-text-light, #777);
+  }
+
+  .reset-button {
+    background: none;
+    border: 1px solid var(--color-gray, #ccc);
+    border-radius: 0.4rem;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    font-size: 1.3rem;
   }
 </style>

--- a/src/lib/components/Map/RouteTweaks.svelte
+++ b/src/lib/components/Map/RouteTweaks.svelte
@@ -108,6 +108,8 @@
         <option value="default">Default</option>
         <option value="kmOnTop">Km markers on top</option>
         <option value="raiseOnHover">Raise route on hover/tap</option>
+        <option value="kmOnTopHover">Km on top + raise on hover/tap</option>
+        <option value="kmOnTopOverlap">Km on top + blend overlaps</option>
       </select>
     </div>
   </section>

--- a/src/lib/components/Map/RouteTweaks.svelte
+++ b/src/lib/components/Map/RouteTweaks.svelte
@@ -9,7 +9,8 @@
     routeTweaks,
     currentMapZoom,
     effectiveKm,
-    type RouteLayerMode
+    type RouteLayerMode,
+    type EndpointMode
   } from '$lib/stores/routeTweaks';
   import { ROUTE_COLORS, DEFAULT_ZOOM_INTERVAL_CONFIG } from '$lib/util/map/routeStyle';
   import { Switch, Modal } from '$lib/components/UI';
@@ -27,6 +28,12 @@
     routeTweaks.update((t) => ({
       ...t,
       routeLayerMode: (e.currentTarget as HTMLSelectElement).value as RouteLayerMode
+    }));
+
+  const onEndpointModeChange = (e: Event) =>
+    routeTweaks.update((t) => ({
+      ...t,
+      endpointMode: (e.currentTarget as HTMLSelectElement).value as EndpointMode
     }));
 
   const onConfigInput = (e: Event) =>
@@ -100,6 +107,14 @@
         ariaLabel="Toggle start and end markers"
         onToggle={() => toggle('showStartEndMarkers')}
       />
+    </div>
+
+    <div class="row">
+      <label class="label" for="endpoint-mode">Start/end style</label>
+      <select id="endpoint-mode" value={$routeTweaks.endpointMode} onchange={onEndpointModeChange}>
+        <option value="icons">Play / stop / pause icons</option>
+        <option value="flags">Circle + finish flag</option>
+      </select>
     </div>
 
     <div class="row">

--- a/src/lib/components/Map/RouteTweaks.svelte
+++ b/src/lib/components/Map/RouteTweaks.svelte
@@ -19,8 +19,15 @@
 
   let showIntervalModal = $state(false);
 
-  const toggle = (key: 'useMultipleColors' | 'showKmMarkers' | 'showStartEndMarkers') =>
-    routeTweaks.update((t) => ({ ...t, [key]: !t[key] }));
+  const toggle = (
+    key:
+      | 'useMultipleColors'
+      | 'showKmMarkers'
+      | 'fadeKmMarkers'
+      | 'showStartEndMarkers'
+      | 'transparentRoutes'
+      | 'showRouteNames'
+  ) => routeTweaks.update((t) => ({ ...t, [key]: !t[key] }));
 
   const setPanelOpen = (panelOpen: boolean) => routeTweaks.update((t) => ({ ...t, panelOpen }));
 
@@ -51,7 +58,7 @@
       ? 'off'
       : !$effectiveKm
         ? 'hidden'
-        : $effectiveKm.opacity < 1
+        : $effectiveKm.opacity < 1 && $routeTweaks.fadeKmMarkers
           ? `${$effectiveKm.interval} km (fading)`
           : `${$effectiveKm.interval} km`
   );
@@ -101,6 +108,15 @@
     </button>
 
     <div class="row">
+      <span class="label">Fade km markers in/out</span>
+      <Switch
+        checked={$routeTweaks.fadeKmMarkers}
+        ariaLabel="Toggle fading of kilometre markers"
+        onToggle={() => toggle('fadeKmMarkers')}
+      />
+    </div>
+
+    <div class="row">
       <span class="label">Show start/end markers</span>
       <Switch
         checked={$routeTweaks.showStartEndMarkers}
@@ -114,7 +130,26 @@
       <select id="endpoint-mode" value={$routeTweaks.endpointMode} onchange={onEndpointModeChange}>
         <option value="icons">Play / stop / pause icons</option>
         <option value="flags">Circle + finish flag</option>
+        <option value="dots">Green start / red end circles</option>
       </select>
+    </div>
+
+    <div class="row">
+      <span class="label">Transparent routes</span>
+      <Switch
+        checked={$routeTweaks.transparentRoutes}
+        ariaLabel="Toggle transparent route lines"
+        onToggle={() => toggle('transparentRoutes')}
+      />
+    </div>
+
+    <div class="row">
+      <span class="label">Show file names along routes</span>
+      <Switch
+        checked={$routeTweaks.showRouteNames}
+        ariaLabel="Toggle route file name labels"
+        onToggle={() => toggle('showRouteNames')}
+      />
     </div>
 
     <div class="row">

--- a/src/lib/components/Map/RouteTweaks.svelte
+++ b/src/lib/components/Map/RouteTweaks.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  /**
+   * Temporary prototype overlay for experimenting with how uploaded routes are displayed.
+   *
+   * NOTE: this is a one-off, self-contained tweaks panel. It can be removed together with
+   * `$lib/stores/routeTweaks` and the related handling in `FileTrails.svelte`.
+   */
+  import { routeTweaks } from '$lib/stores/routeTweaks';
+  import { ROUTE_COLORS } from '$lib/util/map/routeStyle';
+  import { Switch } from '$lib/components/UI';
+  import Icon from '$lib/components/UI/Icon.svelte';
+  import { crossIcon } from '$lib/images/icons';
+
+  const toggle = (key: 'useMultipleColors' | 'showKmMarkers' | 'showStartEndMarkers') =>
+    routeTweaks.update((t) => ({ ...t, [key]: !t[key] }));
+
+  const onIntervalInput = (e: Event) => {
+    const value = parseFloat((e.currentTarget as HTMLInputElement).value);
+    if (!Number.isNaN(value) && value > 0) {
+      routeTweaks.update((t) => ({ ...t, kmInterval: value }));
+    }
+  };
+
+  const setPanelOpen = (panelOpen: boolean) => routeTweaks.update((t) => ({ ...t, panelOpen }));
+</script>
+
+{#if $routeTweaks.panelOpen}
+  <section class="route-tweaks" aria-label="Route display tweaks">
+    <header>
+      <h3>Route tweaks <span class="badge">prototype</span></h3>
+      <button class="close" aria-label="Close tweaks panel" onclick={() => setPanelOpen(false)}>
+        <Icon icon={crossIcon} />
+      </button>
+    </header>
+
+    <div class="row">
+      <span class="label">Distinguish routes by colour</span>
+      <Switch
+        checked={$routeTweaks.useMultipleColors}
+        ariaLabel="Toggle multiple route colours"
+        onToggle={() => toggle('useMultipleColors')}
+      />
+    </div>
+
+    {#if $routeTweaks.useMultipleColors}
+      <div class="legend">
+        {#each ROUTE_COLORS as color}
+          <span class="swatch" style:background={color}></span>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="row">
+      <span class="label">Show km markers</span>
+      <Switch
+        checked={$routeTweaks.showKmMarkers}
+        ariaLabel="Toggle kilometre markers"
+        onToggle={() => toggle('showKmMarkers')}
+      />
+    </div>
+
+    <div class="row">
+      <label class="label" for="km-interval">Km marker interval</label>
+      <input
+        id="km-interval"
+        type="number"
+        min="0.1"
+        step="0.1"
+        value={$routeTweaks.kmInterval}
+        oninput={onIntervalInput}
+        disabled={!$routeTweaks.showKmMarkers}
+      />
+    </div>
+
+    <div class="row">
+      <span class="label">Show start/end markers</span>
+      <Switch
+        checked={$routeTweaks.showStartEndMarkers}
+        ariaLabel="Toggle start and end markers"
+        onToggle={() => toggle('showStartEndMarkers')}
+      />
+    </div>
+  </section>
+{:else}
+  <button class="route-tweaks-reopen" onclick={() => setPanelOpen(true)}> Route tweaks </button>
+{/if}
+
+<style>
+  .route-tweaks {
+    position: absolute;
+    top: calc(env(safe-area-inset-top, 0px) + 4.5rem);
+    right: 0.8rem;
+    z-index: 20;
+    width: 24rem;
+    max-width: calc(100vw - 1.6rem);
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 0.6rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+    padding: 1rem 1.2rem 1.2rem;
+    font-size: 1.4rem;
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.6rem;
+  }
+
+  h3 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .badge {
+    font-size: 1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #fff;
+    background: var(--color-orange, #e65100);
+    border-radius: 0.3rem;
+    padding: 0.1rem 0.4rem;
+  }
+
+  .close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    width: 2rem;
+    height: 2rem;
+    padding: 0.2rem;
+    flex-shrink: 0;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.5rem 0;
+  }
+
+  .label {
+    line-height: 1.3;
+  }
+
+  input[type='number'] {
+    width: 6rem;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid var(--color-gray, #ccc);
+    border-radius: 0.4rem;
+    font-size: 1.4rem;
+    text-align: right;
+  }
+
+  input[type='number']:disabled {
+    opacity: 0.5;
+  }
+
+  .legend {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0 0 0.4rem;
+  }
+
+  .swatch {
+    width: 2.2rem;
+    height: 0.8rem;
+    border-radius: 0.4rem;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+  }
+
+  .route-tweaks-reopen {
+    position: absolute;
+    top: calc(env(safe-area-inset-top, 0px) + 4.5rem);
+    right: 0.8rem;
+    z-index: 20;
+    background: rgba(255, 255, 255, 0.95);
+    border: none;
+    border-radius: 0.6rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+    padding: 0.6rem 1rem;
+    font-size: 1.3rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+</style>

--- a/src/lib/components/UI/LabeledCheckbox.svelte
+++ b/src/lib/components/UI/LabeledCheckbox.svelte
@@ -15,6 +15,8 @@
     onclick?: (e: MouseEvent) => void;
     oninput?: (e: Event) => void;
     onchange?: (e: Event) => void;
+    /** Optional content rendered between the checkbox and the label. */
+    leading?: import('svelte').Snippet;
     children?: import('svelte').Snippet;
   }
 
@@ -32,6 +34,7 @@
     onclick,
     onchange,
     oninput,
+    leading,
     children
   }: Props = $props();
 </script>
@@ -47,6 +50,7 @@
   class="checkbox-container"
 >
   <input id={name} type="checkbox" {disabled} {name} {oninput} bind:checked {onchange} />
+  {@render leading?.()}
   <LabelWithIcon {ellipsis} {compact} title={label} labelFor={name} {icon}
     >{label ?? ''}{@render children?.()}</LabelWithIcon
   >

--- a/src/lib/components/UI/MultiActionLabel.svelte
+++ b/src/lib/components/UI/MultiActionLabel.svelte
@@ -12,6 +12,8 @@
     oninput?: (e: Event) => void;
     onchange: (e: Event) => void;
     onsecondary: (e: MouseEvent) => void;
+    /** Optional content rendered between the checkbox and the label. */
+    leading?: import('svelte').Snippet;
   }
 
   let {
@@ -22,12 +24,13 @@
     disabled = false,
     oninput,
     onchange,
-    onsecondary
+    onsecondary,
+    leading
   }: Props = $props();
 </script>
 
 <div class="multi-action-label">
-  <LabeledCheckbox ellipsis {name} {label} {disabled} {oninput} bind:checked {onchange} />
+  <LabeledCheckbox ellipsis {name} {label} {disabled} {oninput} bind:checked {onchange} {leading} />
   <button
     class="button-unstyle secondary"
     onclick={(e) => {

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -30,8 +30,10 @@ export type RouteLayerMode =
  * - `icons`: play (start), stop square (end), pause bars (merged) — the status quo
  * - `flags`: plain green circle (start) and a checkerboard finish badge (end AND
  *   merged), both with a thin white border
+ * - `dots`: green circle (start), red circle (end) and a vertically split
+ *   half-green/half-red circle (merged start+end), all with a thin white border
  */
-export type EndpointMode = 'icons' | 'flags';
+export type EndpointMode = 'icons' | 'flags' | 'dots';
 
 export type RouteTweaks = {
   /** Whether the tweaks overlay panel itself is visible. */
@@ -40,8 +42,17 @@ export type RouteTweaks = {
   useMultipleColors: boolean;
   /** Show kilometre markers along each route. */
   showKmMarkers: boolean;
+  /**
+   * Fade the km markers in/out around their zoom thresholds. When off, they simply
+   * appear/disappear at full opacity instead of gradually fading.
+   */
+  fadeKmMarkers: boolean;
   /** Show start & end markers at the route extremities. */
   showStartEndMarkers: boolean;
+  /** Draw the route lines semi-transparently so the underlying road stays visible. */
+  transparentRoutes: boolean;
+  /** Show the (GPX) file name as a label repeated along each route. */
+  showRouteNames: boolean;
   /**
    * Zoom→interval rules (one per line, `<min>-<max>,<intervalKm>`) driving the km
    * marker spacing dynamically based on the current map zoom level.
@@ -57,7 +68,10 @@ export const routeTweaks = writable<RouteTweaks>({
   panelOpen: false,
   useMultipleColors: true,
   showKmMarkers: true,
+  fadeKmMarkers: true,
   showStartEndMarkers: true,
+  transparentRoutes: false,
+  showRouteNames: false,
   zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG,
   routeLayerMode: 'kmOnTopOverlap',
   endpointMode: 'flags'

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -14,8 +14,16 @@ import { DEFAULT_ZOOM_INTERVAL_CONFIG } from '$lib/util/map/routeStyle';
  * - `default`: per-route interleaved (a later route can cover earlier markers)
  * - `kmOnTop`: all km markers drawn above all route lines
  * - `raiseOnHover`: hovering/tapping a route brings it and its markers to the top
+ * - `kmOnTopHover`: km markers on top, plus the hover/tap raise behaviour
+ * - `kmOnTopOverlap`: km markers on top, plus shared route segments drawn as a single
+ *   line alternating the two routes' colours
  */
-export type RouteLayerMode = 'default' | 'kmOnTop' | 'raiseOnHover';
+export type RouteLayerMode =
+  | 'default'
+  | 'kmOnTop'
+  | 'raiseOnHover'
+  | 'kmOnTopHover'
+  | 'kmOnTopOverlap';
 
 export type RouteTweaks = {
   /** Whether the tweaks overlay panel itself is visible. */

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -1,0 +1,30 @@
+/**
+ * Temporary prototype store for route-file display "tweaks".
+ *
+ * Controls a one-off overlay on the map that lets us experiment with how uploaded
+ * routes are displayed (colours, kilometre markers, start/end markers).
+ *
+ * NOTE: this is intentionally a self-contained, removable prototype.
+ */
+import { writable } from 'svelte/store';
+
+export type RouteTweaks = {
+  /** Whether the tweaks overlay panel itself is visible. */
+  panelOpen: boolean;
+  /** Use the alternating colour palette instead of a single purple. */
+  useMultipleColors: boolean;
+  /** Show kilometre markers along each route. */
+  showKmMarkers: boolean;
+  /** Interval (in km) between kilometre markers. */
+  kmInterval: number;
+  /** Show start & end markers at the route extremities. */
+  showStartEndMarkers: boolean;
+};
+
+export const routeTweaks = writable<RouteTweaks>({
+  panelOpen: true,
+  useMultipleColors: true,
+  showKmMarkers: true,
+  kmInterval: 1,
+  showStartEndMarkers: true
+});

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -7,6 +7,7 @@
  * NOTE: this is intentionally a self-contained, removable prototype.
  */
 import { writable } from 'svelte/store';
+import { DEFAULT_ZOOM_INTERVAL_CONFIG } from '$lib/util/map/routeStyle';
 
 export type RouteTweaks = {
   /** Whether the tweaks overlay panel itself is visible. */
@@ -15,16 +16,28 @@ export type RouteTweaks = {
   useMultipleColors: boolean;
   /** Show kilometre markers along each route. */
   showKmMarkers: boolean;
-  /** Interval (in km) between kilometre markers. */
-  kmInterval: number;
   /** Show start & end markers at the route extremities. */
   showStartEndMarkers: boolean;
+  /**
+   * Zoom→interval rules (one per line, `<min>-<max>,<intervalKm>`) driving the km
+   * marker spacing dynamically based on the current map zoom level.
+   */
+  zoomIntervalConfig: string;
 };
 
 export const routeTweaks = writable<RouteTweaks>({
   panelOpen: true,
   useMultipleColors: true,
   showKmMarkers: true,
-  kmInterval: 1,
-  showStartEndMarkers: true
+  showStartEndMarkers: true,
+  zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG
 });
+
+/** Live mirror of the current map zoom level, for display in the tweaks panel. */
+export const currentMapZoom = writable<number | null>(null);
+
+/**
+ * The km marker interval + opacity currently in effect for the live zoom level.
+ * `null` means markers are fully hidden.
+ */
+export const effectiveKm = writable<{ interval: number; opacity: number } | null>(null);

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -25,6 +25,14 @@ export type RouteLayerMode =
   | 'kmOnTopHover'
   | 'kmOnTopOverlap';
 
+/**
+ * How start/end/pause markers are drawn:
+ * - `icons`: play (start), stop square (end), pause bars (merged) — the status quo
+ * - `flags`: plain green circle (start) and a checkerboard finish badge (end AND
+ *   merged), both with a thin white border
+ */
+export type EndpointMode = 'icons' | 'flags';
+
 export type RouteTweaks = {
   /** Whether the tweaks overlay panel itself is visible. */
   panelOpen: boolean;
@@ -41,6 +49,8 @@ export type RouteTweaks = {
   zoomIntervalConfig: string;
   /** How overlapping routes & their km markers are stacked. */
   routeLayerMode: RouteLayerMode;
+  /** How start/end/pause markers are drawn. */
+  endpointMode: EndpointMode;
 };
 
 export const routeTweaks = writable<RouteTweaks>({
@@ -49,7 +59,8 @@ export const routeTweaks = writable<RouteTweaks>({
   showKmMarkers: true,
   showStartEndMarkers: true,
   zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG,
-  routeLayerMode: 'default'
+  routeLayerMode: 'default',
+  endpointMode: 'icons'
 });
 
 /** Live mirror of the current map zoom level, for display in the tweaks panel. */

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -9,6 +9,14 @@
 import { writable } from 'svelte/store';
 import { DEFAULT_ZOOM_INTERVAL_CONFIG } from '$lib/util/map/routeStyle';
 
+/**
+ * How overlapping routes & their km markers are stacked:
+ * - `default`: per-route interleaved (a later route can cover earlier markers)
+ * - `kmOnTop`: all km markers drawn above all route lines
+ * - `raiseOnHover`: hovering/tapping a route brings it and its markers to the top
+ */
+export type RouteLayerMode = 'default' | 'kmOnTop' | 'raiseOnHover';
+
 export type RouteTweaks = {
   /** Whether the tweaks overlay panel itself is visible. */
   panelOpen: boolean;
@@ -23,6 +31,8 @@ export type RouteTweaks = {
    * marker spacing dynamically based on the current map zoom level.
    */
   zoomIntervalConfig: string;
+  /** How overlapping routes & their km markers are stacked. */
+  routeLayerMode: RouteLayerMode;
 };
 
 export const routeTweaks = writable<RouteTweaks>({
@@ -30,7 +40,8 @@ export const routeTweaks = writable<RouteTweaks>({
   useMultipleColors: true,
   showKmMarkers: true,
   showStartEndMarkers: true,
-  zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG
+  zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG,
+  routeLayerMode: 'default'
 });
 
 /** Live mirror of the current map zoom level, for display in the tweaks panel. */

--- a/src/lib/stores/routeTweaks.ts
+++ b/src/lib/stores/routeTweaks.ts
@@ -54,13 +54,13 @@ export type RouteTweaks = {
 };
 
 export const routeTweaks = writable<RouteTweaks>({
-  panelOpen: true,
+  panelOpen: false,
   useMultipleColors: true,
   showKmMarkers: true,
   showStartEndMarkers: true,
   zoomIntervalConfig: DEFAULT_ZOOM_INTERVAL_CONFIG,
-  routeLayerMode: 'default',
-  endpointMode: 'icons'
+  routeLayerMode: 'kmOnTopOverlap',
+  endpointMode: 'flags'
 });
 
 /** Live mirror of the current map zoom level, for display in the tweaks panel. */

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -112,3 +112,79 @@ export const computeKmMarkers = (
 
   return { type: 'FeatureCollection', features };
 };
+
+/** A zoom→interval rule: at zoom in `[min, max)` the km marker interval is `interval` km. */
+export type IntervalRule = { min: number; max: number | null; interval: number };
+
+/** How many zoom levels below the lowest rule the km markers fade out over. */
+export const FADE_ZOOM_RANGE = 1;
+
+/**
+ * Default zoom→interval mapping. Lines are `<min>-<max>,<intervalKm>`:
+ * - `11-,1`   interval 1 km at zoom >= 11
+ * - `8-11,5`  interval 5 km at zoom 8–11
+ * - `7-8,10`  interval 10 km at zoom 7–8
+ * Below zoom 7 (small-country-ish) no rule matches, so the markers fade out.
+ */
+export const DEFAULT_ZOOM_INTERVAL_CONFIG = ['11-,1', '8-11,5', '7-8,10'].join('\n');
+
+/**
+ * Parses the zoom-interval config text. Each non-empty, non-comment line has the form
+ * `<min>-<max>,<intervalKm>`, where `max` may be omitted for an open-ended upper bound
+ * (e.g. `11-,1`) and `min` may be omitted for an open-ended lower bound. Floating point
+ * numbers are supported. Invalid lines are ignored.
+ */
+export const parseZoomIntervalConfig = (text: string): IntervalRule[] => {
+  const rules: IntervalRule[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith('//')) continue;
+    const [rangePart, intervalPart] = line.split(',');
+    if (intervalPart === undefined) continue;
+    const rangeMatch = rangePart.trim().match(/^(\d*\.?\d*)\s*-\s*(\d*\.?\d*)$/);
+    if (!rangeMatch) continue;
+    const interval = parseFloat(intervalPart.trim());
+    if (!(interval > 0)) continue;
+    const min = rangeMatch[1] === '' ? -Infinity : parseFloat(rangeMatch[1]);
+    const max = rangeMatch[2] === '' ? null : parseFloat(rangeMatch[2]);
+    if (Number.isNaN(min) || (max !== null && Number.isNaN(max))) continue;
+    rules.push({ min, max, interval });
+  }
+  return rules;
+};
+
+/**
+ * Determines the km marker interval and opacity for the given zoom level, based on the
+ * parsed rules. Returns `null` when no markers should be shown at all (no rules).
+ */
+export const evaluateZoomInterval = (
+  rules: IntervalRule[],
+  zoom: number,
+  fadeRange = FADE_ZOOM_RANGE
+): { interval: number; opacity: number } | null => {
+  if (rules.length === 0) return null;
+  const sorted = [...rules].sort((a, b) => a.min - b.min);
+
+  // Exact match.
+  for (const r of sorted) {
+    if (zoom >= r.min && (r.max === null || zoom < r.max)) {
+      return { interval: r.interval, opacity: 1 };
+    }
+  }
+
+  // Below the most zoomed-out rule: fade out over `fadeRange` zoom levels.
+  const lowest = sorted[0];
+  if (zoom < lowest.min) {
+    const opacity = Math.max(0, Math.min(1, (zoom - (lowest.min - fadeRange)) / fadeRange));
+    return { interval: lowest.interval, opacity };
+  }
+
+  // In a gap between rules (or above all upper bounds): use the closest lower rule.
+  const lowerRules = sorted.filter((r) => zoom >= r.min);
+  if (lowerRules.length) {
+    const r = lowerRules[lowerRules.length - 1];
+    return { interval: r.interval, opacity: 1 };
+  }
+
+  return null;
+};

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -121,8 +121,9 @@ export type RouteEndpoint = { type: 'start' | 'end' | 'pause'; lngLat: [number, 
 
 /**
  * Merges endpoints that lie within `maxDistanceMeters` of each other into a single
- * marker placed at the cluster's midpoint (centroid). A merged cluster is rendered
- * as a `pause` marker.
+ * marker placed at the cluster's midpoint (centroid). A merged cluster keeps its
+ * shared type when all members are the same (start/end), and is rendered as a
+ * `pause` marker when it mixes types.
  */
 export const clusterEndpoints = (
   endpoints: RouteEndpoint[],
@@ -143,22 +144,24 @@ export const clusterEndpoints = (
     if (cluster.length === 1) return cluster[0];
     const lng = cluster.reduce((sum, m) => sum + m.lngLat[0], 0) / cluster.length;
     const lat = cluster.reduce((sum, m) => sum + m.lngLat[1], 0) / cluster.length;
-    return { type: 'pause', lngLat: [lng, lat] };
+    const allSameType = cluster.every((m) => m.type === cluster[0].type);
+    const type = allSameType ? cluster[0].type : 'pause';
+    return { type, lngLat: [lng, lat] };
   });
 };
 
 /** Zoom thresholds controlling start/end marker shrinking & fading. */
 export const ENDPOINT_FULL_ZOOM = 8.5; // at/above: full size
-export const ENDPOINT_SHRINK_FLOOR = 8; // 8–8.5: shrink down to ENDPOINT_MIN_SCALE
-export const ENDPOINT_FADE_END = 7.5; // 7.5–8: fade out over 0.5 zoom levels; below: hidden
-export const ENDPOINT_MIN_SCALE = 0.45;
+export const ENDPOINT_SHRINK_FLOOR = 8.3; // 8.3–8.5: shrink down to ENDPOINT_MIN_SCALE
+export const ENDPOINT_FADE_END = 7.8; // 7.8–8.3: fade out over 0.5 zoom levels; below: hidden
+export const ENDPOINT_MIN_SCALE = 0.78; // smallest size markers ever reach (the size at zoom 8.3)
 
 /**
  * Computes the start/end marker scale & opacity for a zoom level:
  * - zoom >= 8.5: full size, opaque
- * - 8–8.5: shrinks linearly down to ENDPOINT_MIN_SCALE
- * - 7.5–8: stays small and fades out over 0.5 zoom levels
- * - below 7.5: hidden
+ * - 8.3–8.5: shrinks linearly down to ENDPOINT_MIN_SCALE
+ * - 7.8–8.3: stays at the minimum size and fades out over 0.5 zoom levels
+ * - below 7.8: hidden
  */
 export const computeEndpointStyle = (zoom: number): { scale: number; opacity: number } => {
   if (zoom >= ENDPOINT_FULL_ZOOM) return { scale: 1, opacity: 1 };

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -3,8 +3,15 @@
  *
  * NOTE: part of a temporary prototype for route file display enhancements.
  */
-import { along, distance, length, lineString } from '@turf/turf';
-import type { Feature, FeatureCollection, Geometry, Point, Position } from 'geojson';
+import {
+  along,
+  distance,
+  length,
+  lineSliceAlong,
+  lineString,
+  pointToLineDistance
+} from '@turf/turf';
+import type { Feature, FeatureCollection, Geometry, LineString, Point, Position } from 'geojson';
 
 /**
  * Palette used to colour uploaded routes.
@@ -174,6 +181,82 @@ export const computeEndpointStyle = (zoom: number): { scale: number; opacity: nu
     return { scale: ENDPOINT_MIN_SCALE, opacity: t };
   }
   return { scale: ENDPOINT_MIN_SCALE, opacity: 0 };
+};
+
+/** A route paired with the colour it is drawn in on the map. */
+export type ColoredRoute = { color: string; geoJson: FeatureCollection | Feature };
+
+/** Max distance (m) between two routes to count as following "the same path". */
+export const OVERLAP_THRESHOLD_M = 20;
+/** Minimum sustained length (km) for a shared stretch to be treated as an overlap. */
+export const OVERLAP_MIN_LENGTH_KM = 0.1;
+/** Sampling step (km) used when scanning a route for overlaps. */
+export const OVERLAP_SAMPLE_KM = 0.02;
+
+/**
+ * Detects stretches where two routes follow (roughly) the same path — not merely
+ * crossing, but staying within `OVERLAP_THRESHOLD_M` of each other for at least
+ * `OVERLAP_MIN_LENGTH_KM`. Each detected stretch is returned as a LineString carrying
+ * the two routes' colours, so it can be drawn as an alternating two-colour line.
+ *
+ * NOTE: this is an O(pairs × samples × vertices) scan; it is only run in the overlap
+ * display mode (and off the zoom hot path).
+ */
+export const computeOverlapSegments = (
+  routes: ColoredRoute[]
+): FeatureCollection<LineString, { colorA: string; colorB: string }> => {
+  const features: Feature<LineString, { colorA: string; colorB: string }>[] = [];
+  const maxKm = OVERLAP_THRESHOLD_M / 1000;
+  const linesPerRoute = routes.map((r) =>
+    extractLines(r.geoJson).map((coords) => lineString(coords))
+  );
+
+  for (let i = 0; i < routes.length; i++) {
+    for (let j = i + 1; j < routes.length; j++) {
+      const bLines = linesPerRoute[j];
+      if (linesPerRoute[i].length === 0 || bLines.length === 0) continue;
+
+      for (const lineA of linesPerRoute[i]) {
+        const lenKm = length(lineA, { units: 'kilometers' });
+        if (lenKm <= 0) continue;
+
+        // Sample lineA at a fixed spacing (plus its exact end).
+        const dists: number[] = [];
+        for (let d = 0; d < lenKm; d += OVERLAP_SAMPLE_KM) dists.push(d);
+        dists.push(lenKm);
+
+        let runStart: number | null = null;
+        for (let k = 0; k < dists.length; k++) {
+          const d = dists[k];
+          const pt = along(lineA, d, { units: 'kilometers' });
+          const near = bLines.some(
+            (lineB) => pointToLineDistance(pt, lineB, { units: 'kilometers' }) <= maxKm
+          );
+          const isLast = k === dists.length - 1;
+
+          if (near && runStart === null) runStart = d;
+          if ((!near || isLast) && runStart !== null) {
+            const end = near ? d : dists[k - 1];
+            if (end - runStart >= OVERLAP_MIN_LENGTH_KM) {
+              try {
+                const seg = lineSliceAlong(lineA, runStart, end, { units: 'kilometers' });
+                features.push({
+                  type: 'Feature',
+                  geometry: seg.geometry,
+                  properties: { colorA: routes[i].color, colorB: routes[j].color }
+                });
+              } catch {
+                // Degenerate slice; skip.
+              }
+            }
+            runStart = null;
+          }
+        }
+      }
+    }
+  }
+
+  return { type: 'FeatureCollection', features };
 };
 
 /** A zoom→interval rule: at zoom in `[min, max)` the km marker interval is `interval` km. */

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -117,16 +117,14 @@ export const computeKmMarkers = (
 export type IntervalRule = { min: number; max: number | null; interval: number };
 
 /** How many zoom levels below the lowest rule the km markers fade out over. */
-export const FADE_ZOOM_RANGE = 1;
+export const FADE_ZOOM_RANGE = 0.5;
 
 /**
  * Default zoom→interval mapping. Lines are `<min>-<max>,<intervalKm>`:
- * - `11-,1`   interval 1 km at zoom >= 11
- * - `8-11,5`  interval 5 km at zoom 8–11
- * - `7-8,10`  interval 10 km at zoom 7–8
- * Below zoom 7 (small-country-ish) no rule matches, so the markers fade out.
  */
-export const DEFAULT_ZOOM_INTERVAL_CONFIG = ['11-,1', '8-11,5', '7-8,10'].join('\n');
+export const DEFAULT_ZOOM_INTERVAL_CONFIG = `11.5-,1
+9.5-11.5,5
+8.5-9.5,10`;
 
 /**
  * Parses the zoom-interval config text. Each non-empty, non-comment line has the form

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -1,0 +1,114 @@
+/**
+ * Helpers for styling uploaded route (trail) files on the map.
+ *
+ * NOTE: part of a temporary prototype for route file display enhancements.
+ */
+import { along, length, lineString } from '@turf/turf';
+import type { Feature, FeatureCollection, Geometry, Point, Position } from 'geojson';
+
+/**
+ * Palette used to colour uploaded routes.
+ *
+ * The first colour is the original "dark purple" (indigo). The remaining four are
+ * distinct, well-contrasting colours so that touching/overlapping routes can be told
+ * apart. All are dark/saturated enough to stand out against the light green/yellow map.
+ */
+export const ROUTE_COLORS = [
+  '#4b0082', // indigo (original dark purple)
+  '#d7263d', // crimson red
+  '#1565c0', // strong blue
+  '#d81b60', // magenta / deep pink
+  '#e65100' // deep orange
+];
+
+/** The default single colour, used when multi-colouring is toggled off. */
+export const DEFAULT_ROUTE_COLOR = ROUTE_COLORS[0];
+
+/**
+ * Returns the colour for the route at the given index.
+ * @param index position of the route among the uploaded routes
+ * @param useMultipleColors when false, always returns the default colour
+ */
+export const colorForRoute = (index: number, useMultipleColors: boolean): string =>
+  useMultipleColors ? ROUTE_COLORS[index % ROUTE_COLORS.length] : DEFAULT_ROUTE_COLOR;
+
+/** Recursively collects all LineString coordinate arrays from a geometry. */
+const collectLines = (geometry: Geometry, out: Position[][]) => {
+  switch (geometry.type) {
+    case 'LineString':
+      out.push(geometry.coordinates);
+      break;
+    case 'MultiLineString':
+      geometry.coordinates.forEach((coords) => out.push(coords));
+      break;
+    case 'GeometryCollection':
+      geometry.geometries.forEach((g) => collectLines(g, out));
+      break;
+    default:
+      break;
+  }
+};
+
+/** Extracts all usable line segments (>= 2 points) from a GeoJSON route. */
+export const extractLines = (geoJson: FeatureCollection | Feature): Position[][] => {
+  const out: Position[][] = [];
+  const features = geoJson.type === 'FeatureCollection' ? geoJson.features : [geoJson];
+  features.forEach((feature) => {
+    if (feature.geometry) collectLines(feature.geometry, out);
+  });
+  return out.filter((line) => line.length >= 2);
+};
+
+/**
+ * Returns the first and last coordinate of a route, treating the route as the
+ * concatenation of its line segments (first point of the first line, last point
+ * of the last line).
+ */
+export const computeStartEnd = (
+  geoJson: FeatureCollection | Feature
+): { start: Position; end: Position } | null => {
+  const lines = extractLines(geoJson);
+  if (lines.length === 0) return null;
+  const first = lines[0];
+  const last = lines[lines.length - 1];
+  return { start: first[0], end: last[last.length - 1] };
+};
+
+/**
+ * Computes evenly-spaced kilometre markers along a route. Distances are accumulated
+ * across consecutive line segments so labels stay continuous over multi-segment routes.
+ *
+ * @param intervalKm the spacing between markers, in kilometres
+ */
+export const computeKmMarkers = (
+  geoJson: FeatureCollection | Feature,
+  intervalKm: number
+): FeatureCollection<Point, { label: string }> => {
+  const features: Feature<Point, { label: string }>[] = [];
+  const lines = extractLines(geoJson);
+
+  if (intervalKm > 0) {
+    const epsilon = 1e-9;
+    let cumulative = 0; // total distance covered before the current segment
+    let count = 1; // index of the next marker to place
+    for (const coords of lines) {
+      const ls = lineString(coords);
+      const segmentLength = length(ls, { units: 'kilometers' });
+      while (count * intervalKm <= cumulative + segmentLength + epsilon) {
+        const distanceOnSegment = Math.max(0, count * intervalKm - cumulative);
+        const point = along(ls, distanceOnSegment, { units: 'kilometers' });
+        const km = count * intervalKm;
+        const label = Number.isInteger(km) ? `${km}` : `${+km.toFixed(2)}`;
+        features.push({
+          type: 'Feature',
+          geometry: point.geometry,
+          properties: { label }
+        });
+        count++;
+      }
+      cumulative += segmentLength;
+    }
+  }
+
+  return { type: 'FeatureCollection', features };
+};

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -3,14 +3,7 @@
  *
  * NOTE: part of a temporary prototype for route file display enhancements.
  */
-import {
-  along,
-  distance,
-  length,
-  lineSliceAlong,
-  lineString,
-  pointToLineDistance
-} from '@turf/turf';
+import { along, distance, length, lineString } from '@turf/turf';
 import type { Feature, FeatureCollection, Geometry, LineString, Point, Position } from 'geojson';
 
 /**
@@ -190,8 +183,62 @@ export type ColoredRoute = { color: string; geoJson: FeatureCollection | Feature
 export const OVERLAP_THRESHOLD_M = 20;
 /** Minimum sustained length (km) for a shared stretch to be treated as an overlap. */
 export const OVERLAP_MIN_LENGTH_KM = 0.1;
-/** Sampling step (km) used when scanning a route for overlaps. */
-export const OVERLAP_SAMPLE_KM = 0.02;
+/** Vertices closer than this (m) are dropped before scanning (accuracy vs. speed). */
+export const OVERLAP_DECIMATE_M = 10;
+/** Step (m) at which a route is sampled while scanning for overlaps. */
+export const OVERLAP_SAMPLE_M = 25;
+
+// --- Fast local planar geometry (accurate enough at the ~20 m scale) ---
+const M_PER_DEG_LAT = 111_320;
+type XY = [number, number];
+
+/** Squared distance (m²) from point p to segment a–b, in projected metres. */
+const pointSegDist2 = (p: XY, a: XY, b: XY): number => {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  const len2 = dx * dx + dy * dy;
+  let t = len2 > 0 ? ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / len2 : 0;
+  t = t < 0 ? 0 : t > 1 ? 1 : t;
+  const cx = a[0] + t * dx - p[0];
+  const cy = a[1] + t * dy - p[1];
+  return cx * cx + cy * cy;
+};
+
+/** A uniform grid spatial index over projected segments, for fast proximity queries. */
+const makeSegmentGrid = (segments: [XY, XY][], cell: number) => {
+  const grid = new Map<string, [XY, XY][]>();
+  for (const seg of segments) {
+    const [a, b] = seg;
+    const cx0 = Math.floor(Math.min(a[0], b[0]) / cell);
+    const cx1 = Math.floor(Math.max(a[0], b[0]) / cell);
+    const cy0 = Math.floor(Math.min(a[1], b[1]) / cell);
+    const cy1 = Math.floor(Math.max(a[1], b[1]) / cell);
+    for (let cx = cx0; cx <= cx1; cx++) {
+      for (let cy = cy0; cy <= cy1; cy++) {
+        const key = `${cx},${cy}`;
+        const bucket = grid.get(key);
+        if (bucket) bucket.push(seg);
+        else grid.set(key, [seg]);
+      }
+    }
+  }
+  return grid;
+};
+
+const isNearGrid = (grid: Map<string, [XY, XY][]>, p: XY, cell: number, thr2: number): boolean => {
+  const cx = Math.floor(p[0] / cell);
+  const cy = Math.floor(p[1] / cell);
+  for (let ix = cx - 1; ix <= cx + 1; ix++) {
+    for (let iy = cy - 1; iy <= cy + 1; iy++) {
+      const bucket = grid.get(`${ix},${iy}`);
+      if (!bucket) continue;
+      for (const [a, b] of bucket) {
+        if (pointSegDist2(p, a, b) <= thr2) return true;
+      }
+    }
+  }
+  return false;
+};
 
 /**
  * Detects stretches where two routes follow (roughly) the same path — not merely
@@ -199,57 +246,114 @@ export const OVERLAP_SAMPLE_KM = 0.02;
  * `OVERLAP_MIN_LENGTH_KM`. Each detected stretch is returned as a LineString carrying
  * the two routes' colours, so it can be drawn as an alternating two-colour line.
  *
- * NOTE: this is an O(pairs × samples × vertices) scan; it is only run in the overlap
- * display mode (and off the zoom hot path).
+ * Optimised for speed (this is the only heavy path, and runs only in overlap mode):
+ * routes are decimated, projected to a local metric plane, indexed in a uniform grid,
+ * and scanned in a single linear pass — turning the naive O(pairs × samples × vertices)
+ * scan into ~O(vertices + samples).
  */
 export const computeOverlapSegments = (
   routes: ColoredRoute[]
 ): FeatureCollection<LineString, { colorA: string; colorB: string }> => {
   const features: Feature<LineString, { colorA: string; colorB: string }>[] = [];
-  const maxKm = OVERLAP_THRESHOLD_M / 1000;
-  const linesPerRoute = routes.map((r) =>
-    extractLines(r.geoJson).map((coords) => lineString(coords))
-  );
 
-  for (let i = 0; i < routes.length; i++) {
-    for (let j = i + 1; j < routes.length; j++) {
-      const bLines = linesPerRoute[j];
-      if (linesPerRoute[i].length === 0 || bLines.length === 0) continue;
+  // Reference latitude for the local projection (from the first available vertex).
+  let lat0: number | undefined;
+  for (const r of routes) {
+    const lines = extractLines(r.geoJson);
+    if (lines.length && lines[0].length) {
+      lat0 = lines[0][0][1];
+      break;
+    }
+  }
+  if (lat0 === undefined) return { type: 'FeatureCollection', features };
 
-      for (const lineA of linesPerRoute[i]) {
-        const lenKm = length(lineA, { units: 'kilometers' });
-        if (lenKm <= 0) continue;
+  const kx = M_PER_DEG_LAT * Math.cos((lat0 * Math.PI) / 180);
+  const project = (lng: number, lat: number): XY => [lng * kx, lat * M_PER_DEG_LAT];
 
-        // Sample lineA at a fixed spacing (plus its exact end).
-        const dists: number[] = [];
-        for (let d = 0; d < lenKm; d += OVERLAP_SAMPLE_KM) dists.push(d);
-        dists.push(lenKm);
+  // Preprocess each route: decimate vertices, project to metres, and index its segments.
+  const decimate2 = OVERLAP_DECIMATE_M * OVERLAP_DECIMATE_M;
+  const prepped = routes.map((r) => {
+    const lines: { ll: [number, number][]; xy: XY[] }[] = [];
+    const segments: [XY, XY][] = [];
+    for (const coords of extractLines(r.geoJson)) {
+      const ll: [number, number][] = [];
+      const xy: XY[] = [];
+      let last: XY | null = null;
+      for (let idx = 0; idx < coords.length; idx++) {
+        const lng = coords[idx][0];
+        const lat = coords[idx][1];
+        const p = project(lng, lat);
+        const keep =
+          idx === 0 ||
+          idx === coords.length - 1 ||
+          !last ||
+          (p[0] - last[0]) ** 2 + (p[1] - last[1]) ** 2 >= decimate2;
+        if (keep) {
+          ll.push([lng, lat]);
+          xy.push(p);
+          last = p;
+        }
+      }
+      if (xy.length >= 2) {
+        lines.push({ ll, xy });
+        for (let s = 0; s < xy.length - 1; s++) segments.push([xy[s], xy[s + 1]]);
+      }
+    }
+    return { color: r.color, lines, grid: makeSegmentGrid(segments, OVERLAP_THRESHOLD_M) };
+  });
 
-        let runStart: number | null = null;
-        for (let k = 0; k < dists.length; k++) {
-          const d = dists[k];
-          const pt = along(lineA, d, { units: 'kilometers' });
-          const near = bLines.some(
-            (lineB) => pointToLineDistance(pt, lineB, { units: 'kilometers' }) <= maxKm
-          );
-          const isLast = k === dists.length - 1;
+  const thr2 = OVERLAP_THRESHOLD_M * OVERLAP_THRESHOLD_M;
+  const minLenM = OVERLAP_MIN_LENGTH_KM * 1000;
 
-          if (near && runStart === null) runStart = d;
-          if ((!near || isLast) && runStart !== null) {
-            const end = near ? d : dists[k - 1];
-            if (end - runStart >= OVERLAP_MIN_LENGTH_KM) {
-              try {
-                const seg = lineSliceAlong(lineA, runStart, end, { units: 'kilometers' });
+  for (let i = 0; i < prepped.length; i++) {
+    for (let j = i + 1; j < prepped.length; j++) {
+      const a = prepped[i];
+      const b = prepped[j];
+      if (!a.lines.length || !b.lines.length) continue;
+
+      for (const line of a.lines) {
+        // Single linear walk of the line, sampling every OVERLAP_SAMPLE_M metres and
+        // testing proximity to route B via its grid; collect runs of "near" samples.
+        const samples: { near: boolean; ll: [number, number] }[] = [];
+        let acc = 0;
+        let next = 0;
+        for (let k = 0; k < line.xy.length - 1; k++) {
+          const p0 = line.xy[k];
+          const p1 = line.xy[k + 1];
+          const l0 = line.ll[k];
+          const l1 = line.ll[k + 1];
+          const segLen = Math.hypot(p1[0] - p0[0], p1[1] - p0[1]);
+          if (segLen === 0) continue;
+          while (next <= acc + segLen + 1e-6) {
+            const t = (next - acc) / segLen;
+            const p: XY = [p0[0] + t * (p1[0] - p0[0]), p0[1] + t * (p1[1] - p0[1])];
+            samples.push({
+              near: isNearGrid(b.grid, p, OVERLAP_THRESHOLD_M, thr2),
+              ll: [l0[0] + t * (l1[0] - l0[0]), l0[1] + t * (l1[1] - l0[1])]
+            });
+            next += OVERLAP_SAMPLE_M;
+          }
+          acc += segLen;
+        }
+
+        let start = -1;
+        for (let k = 0; k < samples.length; k++) {
+          const near = samples[k].near;
+          const last = k === samples.length - 1;
+          if (near && start < 0) start = k;
+          if ((!near || last) && start >= 0) {
+            const endIdx = near ? k : k - 1;
+            if ((endIdx - start) * OVERLAP_SAMPLE_M >= minLenM) {
+              const coordinates = samples.slice(start, endIdx + 1).map((s) => s.ll);
+              if (coordinates.length >= 2) {
                 features.push({
                   type: 'Feature',
-                  geometry: seg.geometry,
-                  properties: { colorA: routes[i].color, colorB: routes[j].color }
+                  geometry: { type: 'LineString', coordinates },
+                  properties: { colorA: a.color, colorB: b.color }
                 });
-              } catch {
-                // Degenerate slice; skip.
               }
             }
-            runStart = null;
+            start = -1;
           }
         }
       }

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -113,13 +113,16 @@ export const computeKmMarkers = (
   return { type: 'FeatureCollection', features };
 };
 
-/** A start/end marker at a route extremity. */
-export type RouteEndpoint = { type: 'start' | 'end'; lngLat: [number, number] };
+/**
+ * A route extremity marker. `pause` is used for points produced by merging nearby
+ * endpoints (see clusterEndpoints).
+ */
+export type RouteEndpoint = { type: 'start' | 'end' | 'pause'; lngLat: [number, number] };
 
 /**
  * Merges endpoints that lie within `maxDistanceMeters` of each other into a single
- * marker placed at the cluster's midpoint (centroid). A merged cluster is always
- * rendered as a `start` marker.
+ * marker placed at the cluster's midpoint (centroid). A merged cluster is rendered
+ * as a `pause` marker.
  */
 export const clusterEndpoints = (
   endpoints: RouteEndpoint[],
@@ -140,22 +143,22 @@ export const clusterEndpoints = (
     if (cluster.length === 1) return cluster[0];
     const lng = cluster.reduce((sum, m) => sum + m.lngLat[0], 0) / cluster.length;
     const lat = cluster.reduce((sum, m) => sum + m.lngLat[1], 0) / cluster.length;
-    return { type: 'start', lngLat: [lng, lat] };
+    return { type: 'pause', lngLat: [lng, lat] };
   });
 };
 
 /** Zoom thresholds controlling start/end marker shrinking & fading. */
 export const ENDPOINT_FULL_ZOOM = 8.5; // at/above: full size
-export const ENDPOINT_SHRINK_FLOOR = 7; // 7–8.5: shrink down to ENDPOINT_MIN_SCALE
-export const ENDPOINT_FADE_END = 6.5; // 6.5–7: fade out; below: hidden
+export const ENDPOINT_SHRINK_FLOOR = 8; // 8–8.5: shrink down to ENDPOINT_MIN_SCALE
+export const ENDPOINT_FADE_END = 7.5; // 7.5–8: fade out over 0.5 zoom levels; below: hidden
 export const ENDPOINT_MIN_SCALE = 0.45;
 
 /**
  * Computes the start/end marker scale & opacity for a zoom level:
  * - zoom >= 8.5: full size, opaque
- * - 7–8.5: shrinks linearly down to ENDPOINT_MIN_SCALE
- * - 6.5–7: stays small and fades out over 0.5 zoom levels
- * - below 6.5: hidden
+ * - 8–8.5: shrinks linearly down to ENDPOINT_MIN_SCALE
+ * - 7.5–8: stays small and fades out over 0.5 zoom levels
+ * - below 7.5: hidden
  */
 export const computeEndpointStyle = (zoom: number): { scale: number; opacity: number } => {
   if (zoom >= ENDPOINT_FULL_ZOOM) return { scale: 1, opacity: 1 };

--- a/src/lib/util/map/routeStyle.ts
+++ b/src/lib/util/map/routeStyle.ts
@@ -3,7 +3,7 @@
  *
  * NOTE: part of a temporary prototype for route file display enhancements.
  */
-import { along, length, lineString } from '@turf/turf';
+import { along, distance, length, lineString } from '@turf/turf';
 import type { Feature, FeatureCollection, Geometry, Point, Position } from 'geojson';
 
 /**
@@ -111,6 +111,63 @@ export const computeKmMarkers = (
   }
 
   return { type: 'FeatureCollection', features };
+};
+
+/** A start/end marker at a route extremity. */
+export type RouteEndpoint = { type: 'start' | 'end'; lngLat: [number, number] };
+
+/**
+ * Merges endpoints that lie within `maxDistanceMeters` of each other into a single
+ * marker placed at the cluster's midpoint (centroid). A merged cluster is always
+ * rendered as a `start` marker.
+ */
+export const clusterEndpoints = (
+  endpoints: RouteEndpoint[],
+  maxDistanceMeters = 5
+): RouteEndpoint[] => {
+  const maxKm = maxDistanceMeters / 1000;
+  const clusters: RouteEndpoint[][] = [];
+
+  for (const ep of endpoints) {
+    const cluster = clusters.find((c) =>
+      c.some((m) => distance(m.lngLat, ep.lngLat, { units: 'kilometers' }) <= maxKm)
+    );
+    if (cluster) cluster.push(ep);
+    else clusters.push([ep]);
+  }
+
+  return clusters.map((cluster) => {
+    if (cluster.length === 1) return cluster[0];
+    const lng = cluster.reduce((sum, m) => sum + m.lngLat[0], 0) / cluster.length;
+    const lat = cluster.reduce((sum, m) => sum + m.lngLat[1], 0) / cluster.length;
+    return { type: 'start', lngLat: [lng, lat] };
+  });
+};
+
+/** Zoom thresholds controlling start/end marker shrinking & fading. */
+export const ENDPOINT_FULL_ZOOM = 8.5; // at/above: full size
+export const ENDPOINT_SHRINK_FLOOR = 7; // 7–8.5: shrink down to ENDPOINT_MIN_SCALE
+export const ENDPOINT_FADE_END = 6.5; // 6.5–7: fade out; below: hidden
+export const ENDPOINT_MIN_SCALE = 0.45;
+
+/**
+ * Computes the start/end marker scale & opacity for a zoom level:
+ * - zoom >= 8.5: full size, opaque
+ * - 7–8.5: shrinks linearly down to ENDPOINT_MIN_SCALE
+ * - 6.5–7: stays small and fades out over 0.5 zoom levels
+ * - below 6.5: hidden
+ */
+export const computeEndpointStyle = (zoom: number): { scale: number; opacity: number } => {
+  if (zoom >= ENDPOINT_FULL_ZOOM) return { scale: 1, opacity: 1 };
+  if (zoom >= ENDPOINT_SHRINK_FLOOR) {
+    const t = (zoom - ENDPOINT_SHRINK_FLOOR) / (ENDPOINT_FULL_ZOOM - ENDPOINT_SHRINK_FLOOR);
+    return { scale: ENDPOINT_MIN_SCALE + t * (1 - ENDPOINT_MIN_SCALE), opacity: 1 };
+  }
+  if (zoom >= ENDPOINT_FADE_END) {
+    const t = (zoom - ENDPOINT_FADE_END) / (ENDPOINT_SHRINK_FLOOR - ENDPOINT_FADE_END);
+    return { scale: ENDPOINT_MIN_SCALE, opacity: t };
+  }
+  return { scale: ENDPOINT_MIN_SCALE, opacity: 0 };
 };
 
 /** A zoom→interval rule: at zoom in `[min, max)` the km marker interval is `interval` km. */

--- a/src/routes/[[lang]]/(stateful)/explore/+layout.svelte
+++ b/src/routes/[[lang]]/(stateful)/explore/+layout.svelte
@@ -23,6 +23,7 @@
   import LayersAndTools from '$lib/components/LayersAndTools/LayersAndTools.svelte';
   import FileTrailModal from '$lib/components/Map/FileTrailModal.svelte';
   import FileTrails from '$lib/components/Map/FileTrails.svelte';
+  import RouteTweaks from '$lib/components/Map/RouteTweaks.svelte';
   import type { Garden, LongLat } from '$lib/types/Garden';
   import { savedGardens as savedGardenStore } from '$lib/stores/savedGardens';
   import TrainAndRails from '$lib/components/Map/TrainAndRails.svelte';
@@ -316,6 +317,10 @@
   <!-- TODO: the $currentPosition should be based on IP
     (if it isn't already by default) -->
   <Filter onGoToPlace={goToPlace} closeToLocation={$currentPosition ?? LOCATION_BELGIUM} />
+  {#if $user?.superfan}
+    <!-- Temporary prototype: route file display tweaks overlay -->
+    <RouteTweaks />
+  {/if}
   <FileTrailModal bind:show={showFileTrailModal} />
   <MembershipModal
     bind:show={isShowingMembershipModal}


### PR DESCRIPTION
## Summary

This branch is the self-contained **route display "tweaks" prototype** — a removable overlay (`RouteTweaks.svelte` + `$lib/stores/routeTweaks`) for experimenting with how uploaded GPX/route files are drawn on the map (`FileTrails.svelte`, `$lib/util/map/routeStyle`).

The latest commit adds four new options on top of the existing prototype:

### New in this round

- **New "Start/end style" — "Green start / red end circles"**: a green circle for the start, a **red** circle for the end, and a **vertically split half-green / half-red** circle when a point is both a start and an end (merged cluster). These markers use the same size as the "Circle + finish flag" option and reuse its green.
- **Toggle to disable km-marker fading**: when off, kilometre markers snap in/out at full opacity instead of gradually fading around their zoom thresholds.
- **Toggle for transparent routes**: draws the route lines (and the shared-segment overlap lines) semi-transparently so the underlying road stays visible.
- **Toggle to show file names along routes**: renders each route's GPX file name (extension stripped) repeated along the line as a curved label with a white halo, coloured to match the route.

### Already on this branch (earlier prototype work)

- Multi-colour route palette, zoom-driven km-marker intervals with an editable rules panel, clustered/zoom-scaled start/end markers, "Circle + finish flag" endpoint style, and several overlapping-route layer-stacking modes (incl. blended shared segments).

## Testing

- `yarn check` — no new type errors in the changed files (`FileTrails.svelte`, `RouteTweaks.svelte`, `routeTweaks.ts`); remaining reported errors are pre-existing in unrelated files.
- Changed files formatted with Prettier.

## Notes

This whole feature is intentionally a self-contained, removable prototype — it can be deleted together with `$lib/stores/routeTweaks` and the related handling in `FileTrails.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGgsuVWrNfCpQswrwFpuj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgsuVWrNfCpQswrwFpuj6)_