### PR TITLE
Fix French typo "amil" → "mail" in account deletion text

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1030,7 +1030,7 @@
         "reauthentication-incorrect-password": "Le mot de passe introduit est incorrect, merci d'essayer à nouveau",
         "reauthentication-info": "<span style=\"color:var(--color-danger);\">⚠️ Il y a longtemps que vous vous êtes connecté·e.</span> Pour nous assurer qu'il s'agit bien de vous, introduisez votre mot de passe pour confirmer la suppression:"
       },
-      "intro": "Supprimer votre compte effacera également toutes les données associées, tels que votre adresse amil, votre nom et les informations relatives à votre jardin."
+      "intro": "Supprimer votre compte effacera également toutes les données associées, tels que votre adresse mail, votre nom et les informations relatives à votre jardin."
     },
     "change-email": {
       "modal": {


### PR DESCRIPTION
## Summary
- Fixed a typo in the French locale account deletion text: "votre adresse amil" → "votre adresse mail" (`src/locales/fr.json`)

## Test plan
- [x] Verified the string is only used for the account deletion intro text on the French account page

---
_Generated by [Claude Code](https://claude.ai/code/session_0174aaYL8Hm4bunaLMAfGVnM)_